### PR TITLE
Add map to property detail and home pages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,6 +104,30 @@ Sanity Studio project:
 - `apps/studio/schemaTypes/` - Content schema definitions
 - `apps/studio/sanity.config.ts` - Studio configuration
 
+## Git Workflow
+
+- **Default PR Target**: Create PRs against the `dev` branch, not `main`
+- Feature branches follow the naming convention: `feat/feature-name`
+- Push changes and create PRs using `gh pr create` command
+
+## Page Structure & Routes
+
+### Frontend Routes
+
+- `/` - Home page with search, featured properties, and location map
+- `/propiedades` - Properties listing page
+- `/propiedades/[slug]` - Property detail page with images, description, and location map
+
+### Content Integration
+
+- Property schema includes: title, subtitle, address, description, price, images, operationType (rent/sale), currency, city, and propertyType
+- Site Settings singleton in Sanity stores office address for home page map display
+- All property and site data is fetched server-side via `sanityFetch` for optimal performance
+
+## Components
+
+- **MapSection** - Reusable component for displaying embedded Google Maps. Renders full-width iframe (450px height) when address is provided, returns null if no address exists.
+
 ## Conventions
 
 - Components in `/app` are Server Components unless marked with `"use client"`
@@ -112,6 +136,6 @@ Sanity Studio project:
 - Dark mode supported via `prefers-color-scheme` CSS media query.
 - Don't add too many comments to the code.
 - Use double quotes for strings (Prettier is pre-configured for this).
-- Use mobile fist for css.
+- Use mobile first for css.
 - Prefer bootstrap css classes and components over custom css.
 - Use CSS over JavaScript when possible for animations and dynamic behavior.

--- a/apps/frontend/src/app/page.tsx
+++ b/apps/frontend/src/app/page.tsx
@@ -3,6 +3,7 @@ import { sanityFetch } from "@/sanity/lib/live";
 import FeaturedProperties from "@/components/FeaturedProperties";
 import SearchProperties from "@/components/SearchProperties";
 import TextImageSection from "@/components/TextImageSection";
+import MapSection from "@/components/MapSection";
 
 const CITIES_QUERY = defineQuery(`
   *[_type == "city"] | order(name asc) { name, "slug": slug.current }
@@ -16,12 +17,17 @@ const ROOM_COUNTS_QUERY = defineQuery(`
   array::unique(*[_type == "property" && defined(rooms)].rooms) | order(@ asc)
 `);
 
+const MAP_ADDRESS_QUERY = defineQuery(`
+  *[_type == "siteSettings"][0].address
+`);
+
 export default async function Home() {
-  const [{ data: cities }, { data: propertyTypes }, { data: roomCounts }] =
+  const [{ data: cities }, { data: propertyTypes }, { data: roomCounts }, { data: address }] =
     await Promise.all([
       sanityFetch({ query: CITIES_QUERY }),
       sanityFetch({ query: PROPERTY_TYPES_QUERY }),
       sanityFetch({ query: ROOM_COUNTS_QUERY }),
+      sanityFetch({ query: MAP_ADDRESS_QUERY }),
     ]);
 
   const filterOptions = {
@@ -51,6 +57,7 @@ export default async function Home() {
         image="/Images/backgroun.jpg"
         backgroundColor="var(--bs-primary)"
       />
+      <MapSection address={address} />
     </>
   );
 }

--- a/apps/frontend/src/app/propiedades/[slug]/page.tsx
+++ b/apps/frontend/src/app/propiedades/[slug]/page.tsx
@@ -1,10 +1,11 @@
-import { PortableText } from '@portabletext/react';
-import { notFound } from 'next/navigation';
-import { defineQuery } from 'next-sanity';
-import { sanityFetch } from '@/sanity/lib/live';
+import { PortableText } from "@portabletext/react";
+import { notFound } from "next/navigation";
+import { defineQuery } from "next-sanity";
+import { sanityFetch } from "@/sanity/lib/live";
 
-import Breadcrumb from '@/components/Breadcrumb';
-import ImageCarousel from '@/components/ImageCarousel';
+import Breadcrumb from "@/components/Breadcrumb";
+import ImageCarousel from "@/components/ImageCarousel";
+import MapSection from "@/components/MapSection";
 
 const PROPERTY_QUERY = defineQuery(`
   *[_type == "property" && slug.current == $slug][0] 
@@ -38,62 +39,76 @@ export default async function PropertyPage({
   }
 
   return (
-    <div className="container py-5">
-      <div className="row justify-content-center">
-        <div className="col-12 col-lg-10">
-          <Breadcrumb
-            items={[
-              { label: "Inicio", href: "/", isHome: true },
-              { label: "Propiedades", href: "/propiedades" },
-              { label: property.title || "Propiedad" },
-            ]}
-          />
-          <h1 className="text-secondary mb-2" style={{ fontSize: '2.5rem' }}>
-            {property.title}
-          </h1>
-          <div className="d-flex gap-2 mb-2">
-            {property.operationType && (
-              <span className={`badge rounded-pill fs-6 ${property.operationType === 'venta' ? 'bg-success' : 'bg-warning text-dark'}`}>
-                {property.operationType === 'venta' ? 'Venta' : 'Alquiler'}
-              </span>
-            )}
-            {property.propertyType && (
-              <span className="badge rounded-pill bg-info text-white fs-6">
-                {property.propertyType}
-              </span>
-            )}
-          </div>
-
-          <div className="text-primary mb-3" style={{ fontSize: '1.1rem' }}>
-            {property.subtitle && <div>{property.subtitle}</div>}
-            <div>
-              {property.address}
-              {property.address && property.city && ', '}
-              {property.city && <span>{property.city}</span>}
+    <>
+      <div className="container py-5">
+        <div className="row justify-content-center">
+          <div className="col-12 col-lg-10">
+            <Breadcrumb
+              items={[
+                { label: "Inicio", href: "/", isHome: true },
+                { label: "Propiedades", href: "/propiedades" },
+                { label: property.title || "Propiedad" },
+              ]}
+            />
+            <h1 className="text-secondary mb-2" style={{ fontSize: "2.5rem" }}>
+              {property.title}
+            </h1>
+            <div className="d-flex gap-2 mb-2">
+              {property.operationType && (
+                <span
+                  className={`badge rounded-pill fs-6 ${property.operationType === "venta" ? "bg-success" : "bg-warning text-dark"}`}
+                >
+                  {property.operationType === "venta" ? "Venta" : "Alquiler"}
+                </span>
+              )}
+              {property.propertyType && (
+                <span className="badge rounded-pill bg-info text-white fs-6">
+                  {property.propertyType}
+                </span>
+              )}
             </div>
-          </div>
-          <hr className="border-primary mb-4" />
 
-          <ImageCarousel images={property.images ?? []} title={property.title ?? ""} />
-          {property.description && (
-            <div className="mb-5">
-              <PortableText value={property.description} />
+            <div className="text-primary mb-3" style={{ fontSize: "1.1rem" }}>
+              {property.subtitle && <div>{property.subtitle}</div>}
+              <div>
+                {property.address}
+                {property.address && property.city && ", "}
+                {property.city && <span>{property.city}</span>}
+              </div>
             </div>
-          )}
+            <hr className="border-primary mb-4" />
 
-          <hr className="border-secondary my-4" />
-          <div className="d-flex flex-column flex-md-row align-items-center justify-content-between gap-3">
-            <span className="text-primary fw-bold fs-3 fs-md-1" style={{ fontSize: 'clamp(1.5rem, 5vw, 2.5rem)' }}>
-              {property.price != null
-                ? `${property.currency === 'ARS' ? 'ARS' : 'USD'} $${property.price.toLocaleString()}`
-                : 'Consultar precio'}
-            </span>
-            <button className="btn btn-info text-white px-4 py-2 fw-bold w-100 w-md-auto" style={{ maxWidth: '300px' }}>
-              contactate con <span className="fw-bold">dzts</span>
-            </button>
+            <ImageCarousel
+              images={property.images ?? []}
+              title={property.title ?? ""}
+            />
+            {property.description && (
+              <div className="mb-5">
+                <PortableText value={property.description} />
+              </div>
+            )}
+
+            <hr className="border-secondary my-4" />
+            <div className="d-flex flex-column flex-md-row align-items-center justify-content-between gap-3">
+              <span
+                className="text-primary fw-bold fs-3 fs-md-1"
+                style={{ fontSize: "clamp(1.5rem, 5vw, 2.5rem)" }}
+              >
+                {property.price != null
+                  ? `${property.currency === "ARS" ? "ARS" : "USD"} $${property.price.toLocaleString()}`
+                  : "Consultar precio"}
+              </span>
+              <button
+                className="btn btn-info text-white px-4 py-2 fw-bold w-100 w-md-auto"
+                style={{ maxWidth: "300px" }}
+              >
+                contactate con <span className="fw-bold">dzts</span>
+              </button>
+            </div>
           </div>
         </div>
       </div>
-    </div>
+      <MapSection address={property.address} />
+    </>
   );
 }

--- a/apps/frontend/src/components/MapSection.tsx
+++ b/apps/frontend/src/components/MapSection.tsx
@@ -1,0 +1,24 @@
+interface MapSectionProps {
+  address?: string | null;
+}
+
+export default function MapSection({ address }: MapSectionProps) {
+  if (!address) return null;
+
+  const mapSrc = `https://www.google.com/maps?q=${encodeURIComponent(address)}&output=embed`;
+
+  return (
+    <div className="w-100">
+      <div style={{ width: "100%", height: "450px" }}>
+        <iframe
+          src={mapSrc}
+          style={{ border: 0, width: "100%", height: "100%" }}
+          allowFullScreen
+          loading="lazy"
+          referrerPolicy="no-referrer-when-downgrade"
+          title="Ubicación de la oficina"
+        />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add Google Maps embed to the property detail (slug) page showing the property location
- Add Google Maps embed to the home page footer showing the office location from site settings
- Map displays full width at the bottom of each page when address data is available

## Changes
- Created new `MapSection` component for displaying embedded Google Maps
- Integrated map on property detail page with property address
- Integrated map on home page with office address from Sanity site settings
- Responsive design with 450px height iframe

## Test plan
- [x] Navigate to a property detail page and verify map displays at the bottom showing the property location
- [x] Check the home page footer and verify the map displays the office location
- [x] Verify maps are full width and responsive on mobile and desktop
- [x] Test with properties that have no address - map should not render

🤖 Generated with [Claude Code](https://claude.com/claude-code)