### PR TITLE
feat: add robots.txt, sitemap.xml, and llms.txt

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -255,6 +255,7 @@ The frontend uses Next.js 16 cache components (`"use cache"` directive + `cacheL
 - Ensure only one `<h1>` per page. Section headings within page content should use `<h2>` or lower.
 - **robots.txt** (`src/app/robots.ts`): Environment-aware. Blocks all bots in non-production (`VERCEL_ENV !== "production"`), allows indexing in production.
 - **sitemap.xml** (`src/app/sitemap.ts`): Dynamically generated. Includes home, `/propiedades`, and all property detail pages fetched from Sanity.
+- **llms.txt** (`src/app/llms.txt/route.ts`): Markdown file for AI agents/LLMs ([spec](https://llmstxt.org/)). Lists main pages and all properties to help LLMs understand site content.
 
 ## E2E Tests
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,6 +114,7 @@ Each app has its own `.env.local` file with different prefixes (Next.js uses `NE
 | `NEXT_PUBLIC_SANITY_PROJECT_ID`  | Sanity project identifier         |
 | `NEXT_PUBLIC_SANITY_DATASET`     | Sanity dataset name               |
 | `NEXT_PUBLIC_WEB3FORMS_KEY`      | Web3Forms API key for contact form|
+| `NEXT_PUBLIC_SITE_URL`           | Production site URL (for sitemap.xml and robots.txt) |
 | `SANITY_REVALIDATE_SECRET`       | HMAC secret for Sanity webhook (server-only, no `NEXT_PUBLIC_` prefix) |
 
 ### Studio (`apps/studio/.env.local`)
@@ -149,6 +150,8 @@ Sanity Studio project:
 
 ## Git Workflow
 
+- **Always create a feature branch** from `dev` before starting new work: `git checkout dev && git pull && git checkout -b feat/feature-name`
+- **Never commit directly to `dev` or `main`** unless explicitly asked
 - **Default PR Target**: Create PRs against the `dev` branch, not `main`
 - Feature branches follow the naming convention: `feat/feature-name`
 - Push changes and create PRs using `gh pr create` command
@@ -250,6 +253,8 @@ The frontend uses Next.js 16 cache components (`"use cache"` directive + `cacheL
 - Property detail pages include `<script type="application/ld+json">` with Schema.org `RealEstateListing` data (name, price, address, images).
 - Property detail pages generate OpenGraph metadata via `generateMetadata()`.
 - Ensure only one `<h1>` per page. Section headings within page content should use `<h2>` or lower.
+- **robots.txt** (`src/app/robots.ts`): Environment-aware. Blocks all bots in non-production (`VERCEL_ENV !== "production"`), allows indexing in production.
+- **sitemap.xml** (`src/app/sitemap.ts`): Dynamically generated. Includes home, `/propiedades`, and all property detail pages fetched from Sanity.
 
 ## E2E Tests
 

--- a/apps/frontend/.env.example
+++ b/apps/frontend/.env.example
@@ -1,0 +1,12 @@
+# Sanity CMS
+NEXT_PUBLIC_SANITY_PROJECT_ID=your_project_id
+NEXT_PUBLIC_SANITY_DATASET=development
+
+# Web3Forms (https://web3forms.com)
+NEXT_PUBLIC_WEB3FORMS_KEY=your_access_key_here
+
+# Sanity webhook revalidation (generate with: openssl rand -hex 32)
+SANITY_REVALIDATE_SECRET=
+
+# Site URL (used for sitemap.xml and robots.txt)
+NEXT_PUBLIC_SITE_URL=https://yourdomain.com

--- a/apps/frontend/.gitignore
+++ b/apps/frontend/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/apps/frontend/src/app/llms.txt/route.ts
+++ b/apps/frontend/src/app/llms.txt/route.ts
@@ -1,0 +1,43 @@
+import { client } from "@/sanity/lib/client";
+
+interface PropertySlug {
+  slug: string;
+  title: string;
+}
+
+export async function GET() {
+  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://example.com";
+
+  const properties = await client.fetch<PropertySlug[]>(`
+    *[_type == "property" && defined(slug.current)] | order(title asc) {
+      "slug": slug.current,
+      title
+    }
+  `);
+
+  const propertyLinks = properties
+    .map((p) => `- [${p.title}](${baseUrl}/propiedades/${p.slug})`)
+    .join("\n");
+
+  const content = `# DZTS Inmobiliaria
+
+> Catálogo de propiedades inmobiliarias en venta y alquiler en Argentina. Casas, departamentos, terrenos y más.
+
+DZTS Inmobiliaria es un sitio web de bienes raíces que ofrece propiedades en venta y alquiler. El sitio incluye búsqueda con filtros por tipo de operación, tipo de propiedad, localidad y cantidad de dormitorios.
+
+## Páginas principales
+
+- [Inicio](${baseUrl}/): Página principal con buscador y propiedades destacadas
+- [Propiedades](${baseUrl}/propiedades): Listado completo de propiedades con filtros
+
+## Propiedades disponibles
+
+${propertyLinks}
+`;
+
+  return new Response(content, {
+    headers: {
+      "Content-Type": "text/plain; charset=utf-8",
+    },
+  });
+}

--- a/apps/frontend/src/app/robots.ts
+++ b/apps/frontend/src/app/robots.ts
@@ -1,0 +1,24 @@
+import type { MetadataRoute } from "next";
+
+export default function robots(): MetadataRoute.Robots {
+  const isProduction = process.env.VERCEL_ENV === "production";
+
+  if (!isProduction) {
+    return {
+      rules: {
+        userAgent: "*",
+        disallow: "/",
+      },
+    };
+  }
+
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL;
+
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+    },
+    ...(siteUrl && { sitemap: `${siteUrl}/sitemap.xml` }),
+  };
+}

--- a/apps/frontend/src/app/sitemap.ts
+++ b/apps/frontend/src/app/sitemap.ts
@@ -1,0 +1,41 @@
+import type { MetadataRoute } from "next";
+import { client } from "@/sanity/lib/client";
+
+interface PropertySlug {
+  slug: string;
+  _updatedAt: string;
+}
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://example.com";
+
+  const properties = await client.fetch<PropertySlug[]>(`
+    *[_type == "property" && defined(slug.current)] {
+      "slug": slug.current,
+      _updatedAt
+    }
+  `);
+
+  const propertyUrls: MetadataRoute.Sitemap = properties.map((property) => ({
+    url: `${baseUrl}/propiedades/${property.slug}`,
+    lastModified: new Date(property._updatedAt),
+    changeFrequency: "weekly",
+    priority: 0.8,
+  }));
+
+  return [
+    {
+      url: baseUrl,
+      lastModified: new Date(),
+      changeFrequency: "daily",
+      priority: 1,
+    },
+    {
+      url: `${baseUrl}/propiedades`,
+      lastModified: new Date(),
+      changeFrequency: "daily",
+      priority: 0.9,
+    },
+    ...propertyUrls,
+  ];
+}


### PR DESCRIPTION
## Summary

- **robots.txt**: Environment-aware - blocks all bots in non-production, allows indexing in production
- **sitemap.xml**: Dynamically generated with all properties from Sanity
- **llms.txt**: Markdown file for AI agents following the [llms.txt spec](https://llmstxt.org/)

Also includes:
- Added `NEXT_PUBLIC_SITE_URL` env var for URLs in sitemap/robots
- Fixed `.gitignore` to track `.env.example`
- Updated Git Workflow docs: always create feature branches

## Test plan

- [ ] Verify `/robots.txt` returns disallow in preview, allow in production
- [ ] Verify `/sitemap.xml` lists all properties
- [ ] Verify `/llms.txt` returns valid Markdown with property links
- [ ] Set `NEXT_PUBLIC_SITE_URL` in Vercel production env

🤖 Generated with [Claude Code](https://claude.ai/code)