### PR TITLE
feat: footer contact info, social links, WhatsApp button & SEO

### DIFF
--- a/apps/frontend/src/app/layout.tsx
+++ b/apps/frontend/src/app/layout.tsx
@@ -5,6 +5,7 @@ import { Inter } from "next/font/google";
 import BootstrapClient from "@/components/BootstrapClient";
 import Header from "@/components/Header";
 import Footer from "@/components/Footer";
+import WhatsAppButton from "@/components/WhatsAppButton";
 import { sanityFetch } from "@/sanity/lib/live";
 import { SITE_SETTINGS_QUERY } from "@/sanity/queries/siteSettings";
 import "bootstrap-icons/font/bootstrap-icons.css";
@@ -48,11 +49,19 @@ async function SiteShell({ children }: { children: React.ReactNode }) {
       <Footer
         logo={siteSettings?.logo}
         siteName={siteSettings?.siteName}
-        copyrightText={siteSettings?.copyrightText}
         footerLinks={siteSettings?.footerLinks}
         certificationLogos={siteSettings?.certificationLogos}
         socialLinks={siteSettings?.socialLinks}
+        phone={siteSettings?.phone}
+        email={siteSettings?.email}
+        address={siteSettings?.address}
       />
+      {siteSettings?.whatsappNumber && (
+        <WhatsAppButton
+          whatsappNumber={siteSettings.whatsappNumber}
+          whatsappMessage={siteSettings.whatsappMessage}
+        />
+      )}
     </>
   );
 }

--- a/apps/frontend/src/app/page.tsx
+++ b/apps/frontend/src/app/page.tsx
@@ -12,6 +12,10 @@ import {
   getCachedHomeContent,
 } from "@/sanity/queries/homePage";
 import { getCachedHomeSeo, getCachedSiteSeo } from "@/sanity/queries/seo";
+import {
+  getCachedOrganization,
+  buildOrganizationJsonLd,
+} from "@/sanity/queries/siteSettings";
 import { resolveMetadata } from "@/lib/seo";
 import FeaturedProperties from "@/components/FeaturedProperties";
 import SearchProperties from "@/components/SearchProperties";
@@ -49,20 +53,41 @@ async function getCachedMapAddress() {
 }
 
 export default async function Home() {
-  const [cities, propertyTypes, roomCounts, address, sections, homeContent] =
-    await Promise.all([
-      getCachedCities(),
-      getCachedPropertyTypes(),
-      getCachedRoomCounts(),
-      getCachedMapAddress(),
-      getCachedHomeSections(),
-      getCachedHomeContent(),
-    ]);
+  const [
+    cities,
+    propertyTypes,
+    roomCounts,
+    address,
+    sections,
+    homeContent,
+    organization,
+  ] = await Promise.all([
+    getCachedCities(),
+    getCachedPropertyTypes(),
+    getCachedRoomCounts(),
+    getCachedMapAddress(),
+    getCachedHomeSections(),
+    getCachedHomeContent(),
+    getCachedOrganization(),
+  ]);
 
   const filterOptions = buildFilterOptions(cities, propertyTypes, roomCounts);
 
+  const jsonLd = organization
+    ? {
+        "@context": "https://schema.org",
+        ...buildOrganizationJsonLd(organization),
+      }
+    : null;
+
   return (
     <>
+      {jsonLd && (
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        />
+      )}
       <SearchProperties
         filterOptions={filterOptions}
         heroHeading={homeContent!.heroHeading!}

--- a/apps/frontend/src/app/propiedades/[slug]/page.tsx
+++ b/apps/frontend/src/app/propiedades/[slug]/page.tsx
@@ -8,6 +8,10 @@ import type { SanityImageSource } from "@sanity/image-url";
 import { sanityFetch } from "@/sanity/lib/live";
 import { urlFor } from "@/sanity/lib/image";
 import { getCachedSiteSeo } from "@/sanity/queries/seo";
+import {
+  getCachedOrganization,
+  buildOrganizationJsonLd,
+} from "@/sanity/queries/siteSettings";
 import { resolveMetadata } from "@/lib/seo";
 
 import Breadcrumb from "@/components/Breadcrumb";
@@ -109,7 +113,10 @@ export default async function PropertyPage({
   params: Promise<{ slug: string }>;
 }) {
   const { slug } = await params;
-  const property = await getCachedProperty(slug);
+  const [property, organization] = await Promise.all([
+    getCachedProperty(slug),
+    getCachedOrganization(),
+  ]);
 
   if (!property) {
     notFound();
@@ -141,6 +148,9 @@ export default async function PropertyPage({
       },
     }),
     ...(imageUrls.length > 0 && { image: imageUrls }),
+    ...(organization && {
+      offeredBy: buildOrganizationJsonLd(organization),
+    }),
   };
 
   return (

--- a/apps/frontend/src/components/Footer.css
+++ b/apps/frontend/src/components/Footer.css
@@ -3,6 +3,37 @@
   padding: 1.5rem 0;
 }
 
+.footer-contact {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  padding-bottom: 1rem;
+  margin-bottom: 1rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.15);
+}
+
+.footer-contact-item {
+  color: rgba(255, 255, 255, 0.8);
+  font-size: 0.875rem;
+  text-decoration: none;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+a.footer-contact-item:hover {
+  color: #fff;
+}
+
+@media (min-width: 768px) {
+  .footer-contact {
+    flex-direction: row;
+    justify-content: center;
+    gap: 2rem;
+  }
+}
+
 .footer-content {
   display: flex;
   align-items: center;
@@ -42,11 +73,23 @@
   color: #3d3d3d;
 }
 
-.copyright {
-  color: #fff;
-  font-size: 0.875rem;
-  margin: 0;
+.footer-social {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
 }
+
+.footer-social a {
+  color: #fff;
+  font-size: 1.25rem;
+  text-decoration: none;
+  transition: opacity 0.2s;
+}
+
+.footer-social a:hover {
+  opacity: 0.7;
+}
+
 
 .footer-certifications {
   display: flex;
@@ -57,7 +100,7 @@
 .cert-placeholder {
   width: 50px;
   height: 50px;
-  background-color: var(--bs-primary);
+  background-color: transparent;
   border-radius: 4px;
   display: flex;
   align-items: center;

--- a/apps/frontend/src/components/Footer.tsx
+++ b/apps/frontend/src/components/Footer.tsx
@@ -9,17 +9,30 @@ type SiteSettings = NonNullable<SITE_SETTINGS_QUERY_RESULT>;
 type FooterProps = {
   logo?: SiteSettings["logo"];
   siteName?: SiteSettings["siteName"];
-  copyrightText?: SiteSettings["copyrightText"];
   footerLinks?: SiteSettings["footerLinks"];
   certificationLogos?: SiteSettings["certificationLogos"];
   socialLinks?: SiteSettings["socialLinks"];
+  phone?: SiteSettings["phone"];
+  email?: SiteSettings["email"];
+  address?: SiteSettings["address"];
+};
+
+const platformIcons: Record<string, string> = {
+  facebook: "bi-facebook",
+  instagram: "bi-instagram",
+  twitter: "bi-twitter-x",
+  linkedin: "bi-linkedin",
+  youtube: "bi-youtube",
 };
 
 export default function Footer({
   logo,
   siteName,
-  copyrightText,
   certificationLogos,
+  socialLinks,
+  phone,
+  email,
+  address,
 }: FooterProps) {
   const logoUrl = logo?.asset ? urlFor(logo).width(300).url() : null;
   const logoAlt = logo?.alt || siteName || "";
@@ -27,6 +40,33 @@ export default function Footer({
   return (
     <footer className="site-footer">
       <div className="container">
+        {(phone || email || address) && (
+          <div className="footer-contact">
+            {address && (
+              <a
+                href={`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(address)}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="footer-contact-item"
+              >
+                <i className="bi bi-geo-alt"></i>
+                {address}
+              </a>
+            )}
+            {phone && (
+              <a href={`tel:${phone}`} className="footer-contact-item">
+                <i className="bi bi-telephone"></i>
+                {phone}
+              </a>
+            )}
+            {email && (
+              <a href={`mailto:${email}`} className="footer-contact-item">
+                <i className="bi bi-envelope"></i>
+                {email}
+              </a>
+            )}
+          </div>
+        )}
         <div className="footer-content">
           {/* Left: Logo */}
           <div className="footer-logo">
@@ -43,8 +83,20 @@ export default function Footer({
           {/* Center: Back to top + Copyright */}
           <div className="footer-center">
             <ScrollToTopButton />
-            {copyrightText && (
-              <p className="copyright">{copyrightText}</p>
+            {socialLinks && socialLinks.length > 0 && (
+              <div className="footer-social">
+                {socialLinks.map((link) => (
+                  <a
+                    key={link._key}
+                    href={link.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    aria-label={link.platform || ""}
+                  >
+                    <i className={`bi ${platformIcons[link.platform || ""] || ""}`}></i>
+                  </a>
+                ))}
+              </div>
             )}
           </div>
 

--- a/apps/frontend/src/components/Footer.tsx
+++ b/apps/frontend/src/components/Footer.tsx
@@ -36,6 +36,10 @@ export default function Footer({
 }: FooterProps) {
   const logoUrl = logo?.asset ? urlFor(logo).width(300).url() : null;
   const logoAlt = logo?.alt || siteName || "";
+  const socialLinksWithUrl = socialLinks?.filter(
+    (link): link is NonNullable<typeof link> & { url: string } =>
+      Boolean(link?.url),
+  );
 
   return (
     <footer className="site-footer">
@@ -83,9 +87,9 @@ export default function Footer({
           {/* Center: Back to top + Copyright */}
           <div className="footer-center">
             <ScrollToTopButton />
-            {socialLinks && socialLinks.length > 0 && (
+            {socialLinksWithUrl && socialLinksWithUrl.length > 0 && (
               <div className="footer-social">
-                {socialLinks.map((link) => (
+                {socialLinksWithUrl.map((link) => (
                   <a
                     key={link._key}
                     href={link.url}

--- a/apps/frontend/src/components/PropertyCard.tsx
+++ b/apps/frontend/src/components/PropertyCard.tsx
@@ -60,7 +60,7 @@ export default function PropertyCard({
           )}
         </div>
         <div className="w-100 bg-primary" style={{ height: 4 }}></div>
-        <div className="card-body text-center pb-2">
+        <div className="card-body text-center pb-2 bg-light rounded-bottom-4">
           <h5 className="fw-bold text-primary mb-2 fs-5">{title}</h5>
           {(city || rooms) && (
             <p className="mb-2 text-muted small">

--- a/apps/frontend/src/components/WhatsAppButton.css
+++ b/apps/frontend/src/components/WhatsAppButton.css
@@ -1,0 +1,24 @@
+.whatsapp-float {
+  position: fixed;
+  bottom: 1.5rem;
+  right: 1.5rem;
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  background-color: #25d366;
+  color: #fff;
+  font-size: 1.75rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-decoration: none;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
+  transition: transform 0.2s, box-shadow 0.2s;
+  z-index: 1000;
+}
+
+.whatsapp-float:hover {
+  transform: scale(1.1);
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.3);
+  color: #fff;
+}

--- a/apps/frontend/src/components/WhatsAppButton.tsx
+++ b/apps/frontend/src/components/WhatsAppButton.tsx
@@ -1,0 +1,24 @@
+import "./WhatsAppButton.css";
+
+type WhatsAppButtonProps = {
+  whatsappNumber: string;
+  whatsappMessage?: string | null;
+};
+
+export default function WhatsAppButton({ whatsappNumber, whatsappMessage }: WhatsAppButtonProps) {
+  const url = whatsappMessage
+    ? `https://wa.me/${whatsappNumber}?text=${encodeURIComponent(whatsappMessage)}`
+    : `https://wa.me/${whatsappNumber}`;
+
+  return (
+    <a
+      href={url}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="whatsapp-float"
+      aria-label="Contactar por WhatsApp"
+    >
+      <i className="bi bi-whatsapp"></i>
+    </a>
+  );
+}

--- a/apps/frontend/src/sanity/queries/siteSettings.ts
+++ b/apps/frontend/src/sanity/queries/siteSettings.ts
@@ -24,7 +24,7 @@ export async function getCachedOrganization() {
 export function buildOrganizationJsonLd(
   org: NonNullable<Awaited<ReturnType<typeof getCachedOrganization>>>,
 ) {
-  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "";
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL;
 
   return {
     "@type": "RealEstateAgent",
@@ -42,7 +42,9 @@ export function buildOrganizationJsonLd(
     }),
     ...(org.socialLinks &&
       org.socialLinks.length > 0 && {
-        sameAs: org.socialLinks.map((link) => link.url).filter(Boolean),
+        sameAs: org.socialLinks
+          .map((link: { url?: string | null } | null) => link?.url)
+          .filter((url: string | null | undefined): url is string => Boolean(url)),
       }),
   };
 }

--- a/apps/frontend/src/sanity/queries/siteSettings.ts
+++ b/apps/frontend/src/sanity/queries/siteSettings.ts
@@ -1,4 +1,51 @@
 import { defineQuery } from "next-sanity";
+import { cacheLife, cacheTag } from "next/cache";
+import { sanityFetch } from "@/sanity/lib/live";
+
+const ORGANIZATION_QUERY = defineQuery(`
+  *[_type == "siteSettings"][0] {
+    siteName,
+    logo { asset->{ url } },
+    phone,
+    email,
+    address,
+    socialLinks[] { url }
+  }
+`);
+
+export async function getCachedOrganization() {
+  "use cache";
+  cacheLife("hours");
+  cacheTag("siteSettings");
+  const { data } = await sanityFetch({ query: ORGANIZATION_QUERY });
+  return data;
+}
+
+export function buildOrganizationJsonLd(
+  org: NonNullable<Awaited<ReturnType<typeof getCachedOrganization>>>,
+) {
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "";
+
+  return {
+    "@type": "RealEstateAgent",
+    name: org.siteName,
+    ...(siteUrl && { url: siteUrl }),
+    ...(org.logo?.asset?.url && { logo: org.logo.asset.url }),
+    ...(org.phone && { telephone: org.phone }),
+    ...(org.email && { email: org.email }),
+    ...(org.address && {
+      address: {
+        "@type": "PostalAddress",
+        streetAddress: org.address,
+        addressCountry: "AR",
+      },
+    }),
+    ...(org.socialLinks &&
+      org.socialLinks.length > 0 && {
+        sameAs: org.socialLinks.map((link) => link.url).filter(Boolean),
+      }),
+  };
+}
 
 export const SITE_SETTINGS_QUERY = defineQuery(/* groq */ `
   *[_type == "siteSettings"][0] {
@@ -29,12 +76,12 @@ export const SITE_SETTINGS_QUERY = defineQuery(/* groq */ `
     email,
     address,
     whatsappNumber,
+    whatsappMessage,
     socialLinks[] {
       _key,
       platform,
       url
     },
-    copyrightText,
     footerLinks[] {
       _key,
       label,

--- a/apps/studio/schema.json
+++ b/apps/studio/schema.json
@@ -1065,6 +1065,13 @@
         },
         "optional": true
       },
+      "whatsappMessage": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        },
+        "optional": true
+      },
       "socialLinks": {
         "type": "objectAttribute",
         "value": {
@@ -1128,13 +1135,6 @@
               }
             }
           }
-        },
-        "optional": true
-      },
-      "copyrightText": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
         },
         "optional": true
       },

--- a/apps/studio/schemaTypes/siteSettingsType.ts
+++ b/apps/studio/schemaTypes/siteSettingsType.ts
@@ -143,6 +143,14 @@ export const siteSettingsType = defineType({
       description: "Número con código de país (ej: 5491155667788)",
     }),
     defineField({
+      name: "whatsappMessage",
+      title: "Mensaje predeterminado de WhatsApp",
+      type: "text",
+      group: "contact",
+      rows: 3,
+      description: "Mensaje que se pre-carga al abrir WhatsApp desde el botón flotante.",
+    }),
+    defineField({
       name: "socialLinks",
       title: "Redes Sociales",
       type: "array",
@@ -185,12 +193,6 @@ export const siteSettingsType = defineType({
     }),
 
     // Pie de Página
-    defineField({
-      name: "copyrightText",
-      title: "Texto Footer",
-      type: "string",
-      group: "footer"
-    }),
     defineField({
       name: "footerLinks",
       title: "Enlaces del Footer",


### PR DESCRIPTION
## Summary
- **Footer social links**: Render social media icons (Facebook, Instagram, X, LinkedIn, YouTube) in the footer center column using Bootstrap Icons
- **Footer contact info**: Add phone, email, and address row above the main footer layout with clickable links (tel:, mailto:, Google Maps)
- **Floating WhatsApp button**: Fixed-position button linking to wa.me with configurable pre-filled message from Sanity
- **SEO structured data**: Add `RealEstateAgent` JSON-LD on home page (contact info, social profiles via `sameAs`); add `offeredBy` organization to property detail `RealEstateListing` JSON-LD
- **Schema changes**: Add `whatsappMessage` field; remove unused `copyrightText` field
- **PropertyCard**: Light gray background on card body
- **Certification logos**: Transparent background instead of primary cyan

## Test plan
- [ ] Verify social icons render in footer when socialLinks are configured in Sanity
- [ ] Verify footer contact row shows phone, email, address with correct links
- [ ] Verify WhatsApp floating button appears and links to wa.me with pre-filled message
- [ ] Verify JSON-LD on home page contains RealEstateAgent with sameAs and contact fields
- [ ] Verify JSON-LD on property detail pages includes offeredBy organization
- [ ] Verify PropertyCard has light gray background on both home and /propiedades pages
- [ ] Verify mobile layout stacks footer contact info vertically
- [ ] Run e2e tests to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)