### PR TITLE
feat: add property status field (vendido/alquilado)

### DIFF
--- a/apps/frontend/src/app/llms.txt/route.ts
+++ b/apps/frontend/src/app/llms.txt/route.ts
@@ -9,7 +9,7 @@ export async function GET() {
   const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://example.com";
 
   const properties = await client.fetch<PropertySlug[]>(`
-    *[_type == "property" && defined(slug.current)] | order(title asc) {
+    *[_type == "property" && defined(slug.current) && !(status in ["vendido", "alquilado"])] | order(title asc) {
       "slug": slug.current,
       title
     }

--- a/apps/frontend/src/app/propiedades/[slug]/page.tsx
+++ b/apps/frontend/src/app/propiedades/[slug]/page.tsx
@@ -25,6 +25,7 @@ const PROPERTY_QUERY = defineQuery(`
     price,
     "propertyType": propertyType->name,
     operationType,
+    status,
     currency,
     "city": city->name,
     "images": images[] { asset->{ _id, url, metadata { lqip } } },
@@ -56,6 +57,7 @@ interface PropertyDetail {
   price?: number | null;
   propertyType?: string | null;
   operationType?: string | null;
+  status?: string | null;
   currency?: string | null;
   city?: string | null;
   images?: Array<PropertyImage | null> | null;
@@ -173,6 +175,11 @@ export default async function PropertyPage({
               {property.propertyType && (
                 <span className="badge rounded-pill bg-info text-white fs-6">
                   {property.propertyType}
+                </span>
+              )}
+              {property.status && property.status !== "disponible" && (
+                <span className="badge rounded-pill bg-danger text-white fs-6">
+                  {property.status === "vendido" ? "Vendido" : "Alquilado"}
                 </span>
               )}
             </div>

--- a/apps/frontend/src/app/propiedades/page.tsx
+++ b/apps/frontend/src/app/propiedades/page.tsx
@@ -43,6 +43,7 @@ interface PropertyListItem {
 
 const PROPERTIES_QUERY = defineQuery(`
   *[_type == "property"
+    && !(status in ["vendido", "alquilado"])
     && ($operationType == "" || operationType == $operationType)
     && (count($propertyTypeSlugs) == 0 || propertyType->slug.current in $propertyTypeSlugs)
     && (count($citySlugs) == 0 || city->slug.current in $citySlugs)
@@ -64,6 +65,7 @@ const PROPERTIES_QUERY = defineQuery(`
 
 const COUNT_QUERY = defineQuery(`
   count(*[_type == "property"
+    && !(status in ["vendido", "alquilado"])
     && ($operationType == "" || operationType == $operationType)
     && (count($propertyTypeSlugs) == 0 || propertyType->slug.current in $propertyTypeSlugs)
     && (count($citySlugs) == 0 || city->slug.current in $citySlugs)

--- a/apps/frontend/src/app/sitemap.ts
+++ b/apps/frontend/src/app/sitemap.ts
@@ -10,7 +10,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://example.com";
 
   const properties = await client.fetch<PropertySlug[]>(`
-    *[_type == "property" && defined(slug.current)] {
+    *[_type == "property" && defined(slug.current) && !(status in ["vendido", "alquilado"])] {
       "slug": slug.current,
       _updatedAt
     }

--- a/apps/frontend/src/components/FeaturedProperties.tsx
+++ b/apps/frontend/src/components/FeaturedProperties.tsx
@@ -5,7 +5,7 @@ import { sanityFetch } from "@/sanity/lib/live";
 import PropertyCard from "./PropertyCard";
 
 const FEATURED_QUERY = defineQuery(`*
-  [_type == "property" && featured == true]
+  [_type == "property" && featured == true && !(status in ["vendido", "alquilado"])]
   | order(publishedAt desc)[0...6]
   {
     _id,

--- a/apps/frontend/src/sanity/queries/properties.ts
+++ b/apps/frontend/src/sanity/queries/properties.ts
@@ -11,7 +11,7 @@ export const PROPERTY_TYPES_QUERY = defineQuery(`
 `);
 
 export const ROOM_COUNTS_QUERY = defineQuery(`
-  array::unique(*[_type == "property" && defined(rooms)].rooms) | order(@ asc)
+  array::unique(*[_type == "property" && defined(rooms) && !(status in ["vendido", "alquilado"])].rooms) | order(@ asc)
 `);
 
 export async function getCachedCities() {

--- a/apps/studio/schemaTypes/propertyType.ts
+++ b/apps/studio/schemaTypes/propertyType.ts
@@ -60,6 +60,20 @@ export const propertyType = defineType({
       },
     }),
     defineField({
+      name: "status",
+      title: "Estado",
+      type: "string",
+      options: {
+        list: [
+          { title: "Disponible", value: "disponible" },
+          { title: "Vendido", value: "vendido" },
+          { title: "Alquilado", value: "alquilado" },
+        ],
+        layout: "radio",
+      },
+      initialValue: "disponible",
+    }),
+    defineField({
       name: "propertyType",
       title: "Tipo de propiedad",
       type: "reference",


### PR DESCRIPTION
## Summary

- Add `status` field to the property schema in Sanity Studio with three options: Disponible (default), Vendido, and Alquilado
- Exclude sold/rented properties from listings, featured properties, sitemap, llms.txt, and room count filters
- Property detail pages remain accessible via direct URL and display a red badge when the property is sold or rented

## Test plan

- [ ] Verify the `status` field appears in Sanity Studio with radio buttons (Disponible, Vendido, Alquilado)
- [ ] Set a property to "Vendido" and confirm it no longer appears in `/propiedades` listing or featured section
- [ ] Confirm the sold property is still accessible via `/propiedades/[slug]` and shows a red "Vendido" badge
- [ ] Verify existing properties without a status value still appear in listings normally
- [ ] Check that sitemap.xml and llms.txt exclude non-available properties
- [ ] Run `pnpm --filter dzts-website lint` and `pnpm --filter dzts-website build` — both pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)