### PR TITLE
feat: static property pages and filter UX

### DIFF
--- a/.claude/plans/future-static-generation.md
+++ b/.claude/plans/future-static-generation.md
@@ -14,7 +14,7 @@ Pre-render all property detail pages at build time and keep them fresh on publis
 
 ## Implementation Steps
 
-### 1) Add `generateStaticParams()` for property detail pages
+### 1) Add `generateStaticParams()` for property detail pages (Done)
 **File:** `apps/frontend/src/app/propiedades/[slug]/page.tsx`
 
 - Query all published property slugs from Sanity

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -303,6 +303,7 @@ Frontend environment variables (in `apps/frontend/.env.local`):
 - Disabled pagination controls render as `<span>` instead of `<a>`.
 - Footer certification images are set to `loading="lazy"`.
 - Inter font no longer sets an unused CSS variable.
+- Property detail pages export `generateStaticParams()` to pre-render available property slugs at build time.
 - Webhook revalidation route: `src/app/api/revalidate/route.ts`. Uses `parseBody` from `next-sanity/webhook` for HMAC validation and `revalidateTag(type, "max")` from `next/cache`.
 - In Next.js 16, `revalidateTag()` requires two arguments: `(tag, profile)`. Pass `"max"` as the profile to revalidate all cache entries for a tag regardless of their original `cacheLife`.
 - The `/propiedades` listing page calls `sanityFetch` directly without `"use cache"` (dynamic `searchParams`), so it has no cache tag and is unaffected by revalidation.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -217,6 +217,7 @@ Two GitHub Actions workflows run on PRs to `dev` and `main`:
 - Disabled pagination controls render as `<span>` instead of `<a>`.
 - Footer certification images are set to `loading="lazy"`.
 - Inter font no longer sets an unused CSS variable.
+- Property detail pages export `generateStaticParams()` to pre-render available property slugs at build time.
 
 ## Components
 

--- a/apps/frontend/src/app/propiedades/[slug]/page.tsx
+++ b/apps/frontend/src/app/propiedades/[slug]/page.tsx
@@ -6,6 +6,7 @@ import { notFound } from "next/navigation";
 import { defineQuery } from "next-sanity";
 import type { SanityImageSource } from "@sanity/image-url";
 import { sanityFetch } from "@/sanity/lib/live";
+import { client } from "@/sanity/lib/client";
 import { urlFor } from "@/sanity/lib/image";
 import { getCachedSiteSeo } from "@/sanity/queries/seo";
 import {
@@ -43,6 +44,12 @@ const PROPERTY_QUERY = defineQuery(`
   }
 `);
 
+const PROPERTY_SLUGS_QUERY = defineQuery(`
+  *[_type == "property" && defined(slug.current)]{
+    "slug": slug.current
+  }
+`);
+
 interface PropertyImageAsset {
   _id: string;
   url?: string | null;
@@ -72,6 +79,10 @@ interface PropertyDetail {
     ogImage?: { asset?: { url?: string | null } | null } | null;
     noIndex?: boolean | null;
   } | null;
+}
+
+interface PropertySlugEntry {
+  slug: string;
 }
 
 async function getCachedProperty(slug: string) {
@@ -108,6 +119,11 @@ export async function generateMetadata({
     ogImageUrl,
     canonicalUrl: `/propiedades/${slug}`,
   });
+}
+
+export async function generateStaticParams() {
+  const slugs = await client.fetch<PropertySlugEntry[]>(PROPERTY_SLUGS_QUERY);
+  return slugs.map((entry) => ({ slug: entry.slug }));
 }
 
 export default async function PropertyPage({

--- a/apps/frontend/src/app/propiedades/page.tsx
+++ b/apps/frontend/src/app/propiedades/page.tsx
@@ -43,6 +43,7 @@ interface PropertyListItem {
 
 const PROPERTIES_QUERY = defineQuery(`
   *[_type == "property"
+    && defined(slug.current)
     && !(status in ["vendido", "alquilado"])
     && ($operationType == "" || operationType == $operationType)
     && (count($propertyTypeSlugs) == 0 || propertyType->slug.current in $propertyTypeSlugs)
@@ -65,6 +66,7 @@ const PROPERTIES_QUERY = defineQuery(`
 
 const COUNT_QUERY = defineQuery(`
   count(*[_type == "property"
+    && defined(slug.current)
     && !(status in ["vendido", "alquilado"])
     && ($operationType == "" || operationType == $operationType)
     && (count($propertyTypeSlugs) == 0 || propertyType->slug.current in $propertyTypeSlugs)

--- a/apps/frontend/src/app/sitemap.ts
+++ b/apps/frontend/src/app/sitemap.ts
@@ -14,7 +14,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   }
 
   const properties = await client.fetch<PropertySlug[]>(`
-    *[_type == "property" && defined(slug.current) && !(status in ["vendido", "alquilado"])] {
+    *[_type == "property" && defined(slug.current)] {
       "slug": slug.current,
       _updatedAt
     }

--- a/apps/frontend/src/components/ActiveFilterBadges.tsx
+++ b/apps/frontend/src/components/ActiveFilterBadges.tsx
@@ -1,25 +1,35 @@
 "use client";
 
 import { useRouter, useSearchParams } from "next/navigation";
+import { useEffect, useTransition } from "react";
 import type { FilterOption } from "@/types/filters";
 import { parseMultiple } from "@/lib/filters";
 
 interface ActiveFilterBadgesProps {
   cities: FilterOption[];
   propertyTypes: FilterOption[];
+  onFilteringChange?: (isFiltering: boolean) => void;
 }
 
 export default function ActiveFilterBadges({
   cities,
   propertyTypes,
+  onFilteringChange,
 }: ActiveFilterBadgesProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
+  const [isPending, startTransition] = useTransition();
 
   const appliedOperacion = searchParams.get("operacion") || "";
   const appliedPropiedad = parseMultiple(searchParams.get("propiedad"));
   const appliedLocalidad = parseMultiple(searchParams.get("localidad"));
   const appliedDormitorios = parseMultiple(searchParams.get("dormitorios"));
+
+  useEffect(() => {
+    if (onFilteringChange) {
+      onFilteringChange(isPending);
+    }
+  }, [isPending, onFilteringChange]);
 
   const getOperacionLabel = (value: string) => {
     if (value === "venta") return "Venta";
@@ -93,11 +103,15 @@ export default function ActiveFilterBadges({
 
     params.delete("pagina");
     const queryString = params.toString();
-    router.push(queryString ? `/propiedades?${queryString}` : "/propiedades");
+    startTransition(() => {
+      router.push(queryString ? `/propiedades?${queryString}` : "/propiedades");
+    });
   };
 
   const clearAllFilters = () => {
-    router.push("/propiedades");
+    startTransition(() => {
+      router.push("/propiedades");
+    });
   };
 
   if (appliedFilters.length === 0) {

--- a/apps/frontend/src/components/PropertiesFilters.css
+++ b/apps/frontend/src/components/PropertiesFilters.css
@@ -1,0 +1,15 @@
+.filters-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.filters-section--collapsed {
+  display: none;
+}
+
+@media (min-width: 992px) {
+  .filters-section--collapsed {
+    display: flex;
+  }
+}

--- a/apps/frontend/src/components/PropertiesLayout.css
+++ b/apps/frontend/src/components/PropertiesLayout.css
@@ -7,6 +7,46 @@
     "main";
 }
 
+.properties-layout-wrapper {
+  position: relative;
+}
+
+.properties-loading-overlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+      135deg,
+      rgba(255, 255, 255, 0.9) 0%,
+      rgba(248, 249, 250, 0.85) 100%
+    );
+  backdrop-filter: blur(6px);
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 2.5rem 2rem 2rem;
+  z-index: 5;
+  border-radius: 1rem;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.6);
+}
+
+.properties-loading-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 1.5rem 2rem;
+  border-radius: 999px;
+  background: #ffffff;
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.12);
+  text-align: center;
+  min-width: 240px;
+}
+
+.properties-loading-card .spinner-border {
+  width: 2rem;
+  height: 2rem;
+}
+
 @media (min-width: 992px) {
   .properties-layout {
     grid-template-areas: "filters main";

--- a/apps/frontend/src/components/PropertiesLayout.tsx
+++ b/apps/frontend/src/components/PropertiesLayout.tsx
@@ -18,39 +18,53 @@ export default function PropertiesLayout({
   children,
 }: PropertiesLayoutProps) {
   const [isCollapsed, setIsCollapsed] = useState(false);
+  const [isFiltering, setIsFiltering] = useState(false);
 
   return (
     <Suspense fallback={<div className="bg-light rounded-3 p-4 mb-4" />}>
-      <div
-        className={`properties-layout ${isCollapsed ? "properties-layout--collapsed" : "properties-layout--expanded"}`}
-      >
-        <div style={{ gridArea: "filters" }}>
-          <div className="filters-sticky-wrapper">
-            <PropertiesFilters
-              cities={filterOptions.cities}
-              propertyTypes={filterOptions.propertyTypes}
-              roomCounts={filterOptions.roomCounts}
-              isCollapsed={isCollapsed}
-              onToggleCollapse={() => setIsCollapsed(!isCollapsed)}
-            />
+      <div className="properties-layout-wrapper">
+        {isFiltering && (
+          <div className="properties-loading-overlay" role="status" aria-live="polite">
+            <div className="properties-loading-card">
+              <div className="spinner-border text-primary" aria-hidden="true" />
+              <div className="fw-semibold">Actualizando resultados</div>
+              <div className="text-muted small">Aplicando filtros seleccionados</div>
+            </div>
           </div>
-        </div>
+        )}
+        <div
+          className={`properties-layout ${isCollapsed ? "properties-layout--collapsed" : "properties-layout--expanded"}`}
+        >
+          <div style={{ gridArea: "filters" }}>
+            <div className="filters-sticky-wrapper">
+              <PropertiesFilters
+                cities={filterOptions.cities}
+                propertyTypes={filterOptions.propertyTypes}
+                roomCounts={filterOptions.roomCounts}
+                isCollapsed={isCollapsed}
+                onToggleCollapse={() => setIsCollapsed(!isCollapsed)}
+                onFilteringChange={setIsFiltering}
+              />
+            </div>
+          </div>
 
-        <div style={{ gridArea: "main", minWidth: 0 }}>
+          <div style={{ gridArea: "main", minWidth: 0 }}>
           <ActiveFilterBadges
             cities={filterOptions.cities}
             propertyTypes={filterOptions.propertyTypes}
+            onFilteringChange={setIsFiltering}
           />
 
-          <div className="mb-3" aria-live="polite">
-            <p className="text-muted mb-0">
-              {totalCount === 1
-                ? "1 propiedad encontrada"
-                : `${totalCount} propiedades encontradas`}
-            </p>
-          </div>
+            <div className="mb-3" aria-live="polite">
+              <p className="text-muted mb-0">
+                {totalCount === 1
+                  ? "1 propiedad encontrada"
+                  : `${totalCount} propiedades encontradas`}
+              </p>
+            </div>
 
-          {children}
+            {children}
+          </div>
         </div>
       </div>
     </Suspense>

--- a/apps/studio/schema.json
+++ b/apps/studio/schema.json
@@ -410,6 +410,27 @@
         },
         "optional": true
       },
+      "status": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "union",
+          "of": [
+            {
+              "type": "string",
+              "value": "disponible"
+            },
+            {
+              "type": "string",
+              "value": "vendido"
+            },
+            {
+              "type": "string",
+              "value": "alquilado"
+            }
+          ]
+        },
+        "optional": true
+      },
       "propertyType": {
         "type": "objectAttribute",
         "value": {


### PR DESCRIPTION
## Summary
- pre-render property detail pages from Sanity slugs and include sold/rented entries in sitemap
- add filter loading overlay and collapsible filter sections optimized for smaller screens
- ensure badge-based filter removal shows the loading state

## Testing
- pnpm --filter dzts-website lint
- pnpm --filter dzts-website build
- pnpm --filter dzts-website test:e2e