### PR TITLE
Fix filter URL updates, accordion collapse, and skeleton layout

### DIFF
--- a/apps/frontend/src/app/api/revalidate/route.ts
+++ b/apps/frontend/src/app/api/revalidate/route.ts
@@ -1,10 +1,25 @@
-import { revalidateTag } from "next/cache";
+import { revalidatePath, revalidateTag } from "next/cache";
 import { type NextRequest, NextResponse } from "next/server";
 import { parseBody } from "next-sanity/webhook";
 
+type RevalidatePayload = {
+  _type: string;
+  slug?: {
+    current?: string | null;
+  } | null;
+};
+
+const PATHS_BY_TYPE: Record<string, string[]> = {
+  homePage: ["/"],
+  propiedadesPage: ["/propiedades"],
+  siteSettings: ["/", "/propiedades"],
+  seo: ["/", "/propiedades"],
+  property: ["/propiedades"],
+};
+
 export async function POST(req: NextRequest) {
   try {
-    const { isValidSignature, body } = await parseBody<{ _type: string }>(
+    const { isValidSignature, body } = await parseBody<RevalidatePayload>(
       req,
       process.env.SANITY_REVALIDATE_SECRET,
       true,
@@ -21,6 +36,15 @@ export async function POST(req: NextRequest) {
     }
 
     revalidateTag(body._type, "max");
+
+    const paths = PATHS_BY_TYPE[body._type] ?? [];
+    for (const path of paths) {
+      revalidatePath(path);
+    }
+
+    if (body._type === "property" && body.slug?.current) {
+      revalidatePath(`/propiedades/${body.slug.current}`);
+    }
 
     return NextResponse.json({ revalidated: true, tag: body._type });
   } catch (err) {

--- a/apps/frontend/src/app/api/revalidate/route.ts
+++ b/apps/frontend/src/app/api/revalidate/route.ts
@@ -29,8 +29,6 @@ export async function POST(req: NextRequest) {
       return new Response("Invalid signature", { status: 401 });
     }
 
-    console.log("Revalidating tag:", body);
-
     if (!body?._type) {
       return new Response("Bad request", { status: 400 });
     }

--- a/apps/frontend/src/app/propiedades/loading.tsx
+++ b/apps/frontend/src/app/propiedades/loading.tsx
@@ -8,46 +8,49 @@ export default function PropiedadesLoading() {
       </nav>
       <h1 className="text-center mb-4 fw-bold">Propiedades</h1>
 
-      <div className="properties-layout properties-layout--expanded">
-        <div style={{ gridArea: "filters" }}>
-          <div className="filters-sticky-wrapper">
-            <div className="d-lg-none mb-4 placeholder-glow">
-              <span className="placeholder w-100 d-block" style={{ height: 44 }}></span>
+      <div className="row g-4">
+        {/* Filter sidebar skeleton - desktop only */}
+        <div className="d-none d-lg-block col-lg-3">
+          <div className="bg-light rounded-3 p-3">
+            <div className="placeholder-glow mb-3">
+              <span className="placeholder col-4"></span>
             </div>
-
-            <div className="bg-light rounded-3 p-3">
-              <div className="placeholder-glow mb-3">
-                <span className="placeholder col-4"></span>
-              </div>
-              <div className="placeholder-glow mb-3">
-                <span className="placeholder col-6 d-block mb-2"></span>
-                <span className="placeholder col-8 d-block mb-2"></span>
-                <span className="placeholder col-7 d-block"></span>
-              </div>
-              <div className="placeholder-glow mb-3">
-                <span className="placeholder col-7 d-block mb-2"></span>
-                <span className="placeholder col-9 d-block mb-2"></span>
-                <span className="placeholder col-6 d-block"></span>
-              </div>
-              <div className="placeholder-glow mb-3">
-                <span className="placeholder col-5 d-block mb-2"></span>
-                <span className="placeholder col-8 d-block mb-2"></span>
-                <span className="placeholder col-6 d-block"></span>
-              </div>
-              <div className="placeholder-glow mb-4">
-                <span className="placeholder col-4 d-block mb-2"></span>
-                <span className="placeholder col-7 d-block mb-2"></span>
-                <span className="placeholder col-6 d-block"></span>
-              </div>
-              <div className="placeholder-glow">
-                <span className="placeholder w-100 d-block mb-2" style={{ height: 40 }}></span>
-                <span className="placeholder w-100 d-block" style={{ height: 40 }}></span>
-              </div>
+            <div className="placeholder-glow mb-3">
+              <span className="placeholder col-6 d-block mb-2"></span>
+              <span className="placeholder col-8 d-block mb-2"></span>
+              <span className="placeholder col-7 d-block"></span>
+            </div>
+            <div className="placeholder-glow mb-3">
+              <span className="placeholder col-7 d-block mb-2"></span>
+              <span className="placeholder col-9 d-block mb-2"></span>
+              <span className="placeholder col-6 d-block"></span>
+            </div>
+            <div className="placeholder-glow mb-3">
+              <span className="placeholder col-5 d-block mb-2"></span>
+              <span className="placeholder col-8 d-block mb-2"></span>
+              <span className="placeholder col-6 d-block"></span>
+            </div>
+            <div className="placeholder-glow mb-4">
+              <span className="placeholder col-4 d-block mb-2"></span>
+              <span className="placeholder col-7 d-block mb-2"></span>
+              <span className="placeholder col-6 d-block"></span>
+            </div>
+            <div className="placeholder-glow">
+              <span className="placeholder w-100 d-block mb-2" style={{ height: 40 }}></span>
+              <span className="placeholder w-100 d-block" style={{ height: 40 }}></span>
             </div>
           </div>
         </div>
 
-        <div style={{ gridArea: "main", minWidth: 0 }}>
+        {/* Mobile filter toggle skeleton */}
+        <div className="d-lg-none col-12">
+          <div className="placeholder-glow mb-4">
+            <span className="placeholder w-100 d-block" style={{ height: 44 }}></span>
+          </div>
+        </div>
+
+        {/* Main content skeleton */}
+        <div className="col-12 col-lg-9">
           <div className="d-flex flex-wrap gap-2 mb-3 placeholder-glow">
             <span className="placeholder rounded-pill" style={{ width: 80, height: 26 }}></span>
             <span className="placeholder rounded-pill" style={{ width: 110, height: 26 }}></span>

--- a/apps/frontend/src/components/PropertiesFilters.css
+++ b/apps/frontend/src/components/PropertiesFilters.css
@@ -3,13 +3,3 @@
   flex-direction: column;
   gap: 0.5rem;
 }
-
-.filters-section--collapsed {
-  display: none;
-}
-
-@media (min-width: 992px) {
-  .filters-section--collapsed {
-    display: flex;
-  }
-}

--- a/apps/frontend/src/components/PropertiesFilters.tsx
+++ b/apps/frontend/src/components/PropertiesFilters.tsx
@@ -19,6 +19,8 @@ type SearchParams = ReturnType<typeof useSearchParams>;
 
 interface PropertiesFiltersInnerProps extends PropertiesFiltersProps {
   searchParams: SearchParams;
+  isPending: boolean;
+  startTransition: (callback: () => void) => void;
 }
 
 function PropertiesFiltersInner({
@@ -29,21 +31,22 @@ function PropertiesFiltersInner({
   onToggleCollapse,
   onFilteringChange,
   searchParams,
+  isPending,
+  startTransition,
 }: PropertiesFiltersInnerProps) {
   const router = useRouter();
   const [isOpenMobile, setIsOpenMobile] = useState(false);
-  const [isPending, startTransition] = useTransition();
   const initialOperacion = searchParams.get("operacion") || "";
   const initialPropiedad = parseMultiple(searchParams.get("propiedad"));
   const initialLocalidad = parseMultiple(searchParams.get("localidad"));
   const initialDormitorios = parseMultiple(searchParams.get("dormitorios"));
 
-  const [expandedSections, setExpandedSections] = useState(() => ({
-    operacion: Boolean(initialOperacion),
-    propiedad: initialPropiedad.length > 0,
-    localidad: initialLocalidad.length > 0,
+  const [expandedSections, setExpandedSections] = useState({
+    operacion: true,
+    propiedad: true,
+    localidad: true,
     dormitorios: initialDormitorios.length > 0,
-  }));
+  });
 
   const [operacion, setOperacion] = useState(initialOperacion);
   const [propiedad, setPropiedad] = useState<string[]>(initialPropiedad);
@@ -51,8 +54,10 @@ function PropertiesFiltersInner({
   const [dormitorios, setDormitorios] = useState<string[]>(initialDormitorios);
 
   const activeFilterCount =
-    (operacion ? 1 : 0) + propiedad.length + localidad.length + dormitorios.length;
-
+    (operacion ? 1 : 0) +
+    propiedad.length +
+    localidad.length +
+    dormitorios.length;
 
   const toggleSection = (key: keyof typeof expandedSections) => {
     setExpandedSections((prev) => ({
@@ -67,11 +72,10 @@ function PropertiesFiltersInner({
     }
   }, [isPending, onFilteringChange]);
 
-
   const toggleArrayValue = (
     arr: string[],
     value: string,
-    setter: (val: string[]) => void
+    setter: (val: string[]) => void,
   ) => {
     if (arr.includes(value)) {
       setter(arr.filter((v) => v !== value));
@@ -86,7 +90,8 @@ function PropertiesFiltersInner({
     if (operacion) params.set("operacion", operacion);
     if (propiedad.length > 0) params.set("propiedad", propiedad.join(","));
     if (localidad.length > 0) params.set("localidad", localidad.join(","));
-    if (dormitorios.length > 0) params.set("dormitorios", dormitorios.join(","));
+    if (dormitorios.length > 0)
+      params.set("dormitorios", dormitorios.join(","));
 
     const queryString = params.toString();
     startTransition(() => {
@@ -117,12 +122,16 @@ function PropertiesFiltersInner({
           aria-expanded={expandedSections.operacion}
           aria-controls="filters-operacion"
         >
-          <span className="fw-semibold small text-uppercase text-muted">Operación</span>
-          <i className={`bi bi-chevron-${expandedSections.operacion ? "up" : "down"}`}></i>
+          <span className="fw-semibold small text-uppercase text-muted">
+            Operación
+          </span>
+          <i
+            className={`bi bi-chevron-${expandedSections.operacion ? "up" : "down"}`}
+          ></i>
         </button>
         <div
           id="filters-operacion"
-          className={`filters-section ${expandedSections.operacion ? "filters-section--expanded mt-2" : "filters-section--collapsed"}`}
+          className={`filters-section collapse${expandedSections.operacion ? " show mt-2" : ""}`}
         >
           <div className="form-check">
             <input
@@ -175,12 +184,16 @@ function PropertiesFiltersInner({
           aria-expanded={expandedSections.propiedad}
           aria-controls="filters-propiedad"
         >
-          <span className="fw-semibold small text-uppercase text-muted">Tipo de propiedad</span>
-          <i className={`bi bi-chevron-${expandedSections.propiedad ? "up" : "down"}`}></i>
+          <span className="fw-semibold small text-uppercase text-muted">
+            Tipo de propiedad
+          </span>
+          <i
+            className={`bi bi-chevron-${expandedSections.propiedad ? "up" : "down"}`}
+          ></i>
         </button>
         <div
           id="filters-propiedad"
-          className={`filters-section ${expandedSections.propiedad ? "filters-section--expanded mt-2" : "filters-section--collapsed"}`}
+          className={`filters-section collapse${expandedSections.propiedad ? " show mt-2" : ""}`}
         >
           {propertyTypes.map((type) => (
             <div key={type.slug} className="form-check">
@@ -189,9 +202,14 @@ function PropertiesFiltersInner({
                 type="checkbox"
                 id={`propiedad-${type.slug}`}
                 checked={propiedad.includes(type.slug)}
-                onChange={() => toggleArrayValue(propiedad, type.slug, setPropiedad)}
+                onChange={() =>
+                  toggleArrayValue(propiedad, type.slug, setPropiedad)
+                }
               />
-              <label className="form-check-label" htmlFor={`propiedad-${type.slug}`}>
+              <label
+                className="form-check-label"
+                htmlFor={`propiedad-${type.slug}`}
+              >
                 {type.name}
               </label>
             </div>
@@ -211,12 +229,16 @@ function PropertiesFiltersInner({
           aria-expanded={expandedSections.localidad}
           aria-controls="filters-localidad"
         >
-          <span className="fw-semibold small text-uppercase text-muted">Localidad</span>
-          <i className={`bi bi-chevron-${expandedSections.localidad ? "up" : "down"}`}></i>
+          <span className="fw-semibold small text-uppercase text-muted">
+            Localidad
+          </span>
+          <i
+            className={`bi bi-chevron-${expandedSections.localidad ? "up" : "down"}`}
+          ></i>
         </button>
         <div
           id="filters-localidad"
-          className={`filters-section ${expandedSections.localidad ? "filters-section--expanded mt-2" : "filters-section--collapsed"}`}
+          className={`filters-section collapse${expandedSections.localidad ? " show mt-2" : ""}`}
           style={{ maxHeight: 200, overflowY: "auto" }}
         >
           {cities.map((city) => (
@@ -226,9 +248,14 @@ function PropertiesFiltersInner({
                 type="checkbox"
                 id={`localidad-${city.slug}`}
                 checked={localidad.includes(city.slug)}
-                onChange={() => toggleArrayValue(localidad, city.slug, setLocalidad)}
+                onChange={() =>
+                  toggleArrayValue(localidad, city.slug, setLocalidad)
+                }
               />
-              <label className="form-check-label" htmlFor={`localidad-${city.slug}`}>
+              <label
+                className="form-check-label"
+                htmlFor={`localidad-${city.slug}`}
+              >
                 {city.name}
               </label>
             </div>
@@ -248,12 +275,16 @@ function PropertiesFiltersInner({
           aria-expanded={expandedSections.dormitorios}
           aria-controls="filters-dormitorios"
         >
-          <span className="fw-semibold small text-uppercase text-muted">Dormitorios</span>
-          <i className={`bi bi-chevron-${expandedSections.dormitorios ? "up" : "down"}`}></i>
+          <span className="fw-semibold small text-uppercase text-muted">
+            Dormitorios
+          </span>
+          <i
+            className={`bi bi-chevron-${expandedSections.dormitorios ? "up" : "down"}`}
+          ></i>
         </button>
         <div
           id="filters-dormitorios"
-          className={`filters-section ${expandedSections.dormitorios ? "filters-section--expanded mt-2" : "filters-section--collapsed"}`}
+          className={`filters-section collapse${expandedSections.dormitorios ? " show mt-2" : ""}`}
         >
           {roomCounts.map((count) => (
             <div key={count} className="form-check">
@@ -263,10 +294,17 @@ function PropertiesFiltersInner({
                 id={`dormitorios-${count}`}
                 checked={dormitorios.includes(count.toString())}
                 onChange={() =>
-                  toggleArrayValue(dormitorios, count.toString(), setDormitorios)
+                  toggleArrayValue(
+                    dormitorios,
+                    count.toString(),
+                    setDormitorios,
+                  )
                 }
               />
-              <label className="form-check-label" htmlFor={`dormitorios-${count}`}>
+              <label
+                className="form-check-label"
+                htmlFor={`dormitorios-${count}`}
+              >
                 {count} {count === 1 ? "dormitorio" : "dormitorios"}
               </label>
             </div>
@@ -371,9 +409,7 @@ function PropertiesFiltersInner({
           </div>
 
           {/* Actual filter form */}
-          <div className="bg-light rounded-3 p-3">
-            {filterForm}
-          </div>
+          <div className="bg-light rounded-3 p-3">{filterForm}</div>
         </div>
       )}
     </>
@@ -383,8 +419,15 @@ function PropertiesFiltersInner({
 export default function PropertiesFilters(props: PropertiesFiltersProps) {
   const searchParams = useSearchParams();
   const searchKey = searchParams.toString();
+  const [isPending, startTransition] = useTransition();
 
   return (
-    <PropertiesFiltersInner key={searchKey} searchParams={searchParams} {...props} />
+    <PropertiesFiltersInner
+      key={searchKey}
+      searchParams={searchParams}
+      isPending={isPending}
+      startTransition={startTransition}
+      {...props}
+    />
   );
 }

--- a/apps/frontend/src/sanity/types.ts
+++ b/apps/frontend/src/sanity/types.ts
@@ -473,14 +473,14 @@ export type PROPERTY_QUERY_RESULT = {
 
 // Source: ../frontend/src/app/propiedades/[slug]/page.tsx
 // Variable: PROPERTY_SLUGS_QUERY
-// Query: *[_type == "property" && defined(slug.current) && !(status in ["vendido", "alquilado"])]{    "slug": slug.current  }
+// Query: *[_type == "property" && defined(slug.current)]{    "slug": slug.current  }
 export type PROPERTY_SLUGS_QUERY_RESULT = Array<{
   slug: string | null;
 }>;
 
 // Source: ../frontend/src/app/propiedades/page.tsx
 // Variable: PROPERTIES_QUERY
-// Query: *[_type == "property"    && !(status in ["vendido", "alquilado"])    && ($operationType == "" || operationType == $operationType)    && (count($propertyTypeSlugs) == 0 || propertyType->slug.current in $propertyTypeSlugs)    && (count($citySlugs) == 0 || city->slug.current in $citySlugs)    && (count($roomsList) == 0 || rooms in $roomsList)  ] | order(publishedAt desc)[$start...$end] {    _id,    title,    "slug": slug.current,    subtitle,    price,    currency,    operationType,    "propertyType": propertyType->name,    "city": city->name,    rooms,    "image": images[0] { asset->{ _id, url, metadata { lqip } } }  }
+// Query: *[_type == "property"    && defined(slug.current)    && !(status in ["vendido", "alquilado"])    && ($operationType == "" || operationType == $operationType)    && (count($propertyTypeSlugs) == 0 || propertyType->slug.current in $propertyTypeSlugs)    && (count($citySlugs) == 0 || city->slug.current in $citySlugs)    && (count($roomsList) == 0 || rooms in $roomsList)  ] | order(publishedAt desc)[$start...$end] {    _id,    title,    "slug": slug.current,    subtitle,    price,    currency,    operationType,    "propertyType": propertyType->name,    "city": city->name,    rooms,    "image": images[0] { asset->{ _id, url, metadata { lqip } } }  }
 export type PROPERTIES_QUERY_RESULT = Array<{
   _id: string;
   title: string | null;
@@ -505,7 +505,7 @@ export type PROPERTIES_QUERY_RESULT = Array<{
 
 // Source: ../frontend/src/app/propiedades/page.tsx
 // Variable: COUNT_QUERY
-// Query: count(*[_type == "property"    && !(status in ["vendido", "alquilado"])    && ($operationType == "" || operationType == $operationType)    && (count($propertyTypeSlugs) == 0 || propertyType->slug.current in $propertyTypeSlugs)    && (count($citySlugs) == 0 || city->slug.current in $citySlugs)    && (count($roomsList) == 0 || rooms in $roomsList)  ])
+// Query: count(*[_type == "property"    && defined(slug.current)    && !(status in ["vendido", "alquilado"])    && ($operationType == "" || operationType == $operationType)    && (count($propertyTypeSlugs) == 0 || propertyType->slug.current in $propertyTypeSlugs)    && (count($citySlugs) == 0 || city->slug.current in $citySlugs)    && (count($roomsList) == 0 || rooms in $roomsList)  ])
 export type COUNT_QUERY_RESULT = number;
 
 // Source: ../frontend/src/components/FeaturedProperties.tsx
@@ -756,9 +756,9 @@ declare module "@sanity/client" {
   interface SanityQueries {
     '\n  *[_type == "siteSettings"][0].address\n': MAP_ADDRESS_QUERY_RESULT;
     '\n  *[_type == "property" && slug.current == $slug][0]\n  {\n    title,\n    subtitle,\n    address,\n    description,\n    price,\n    "propertyType": propertyType->name,\n    operationType,\n    status,\n    currency,\n    "city": city->name,\n    "images": images[] { asset->{ _id, url, metadata { lqip } } },\n    "ogImage": images[0],\n    seo {\n      metaTitle,\n      metaDescription,\n      ogImage { asset->{ url } },\n      noIndex\n    }\n  }\n': PROPERTY_QUERY_RESULT;
-    '\n  *[_type == "property" && defined(slug.current) && !(status in ["vendido", "alquilado"])]{\n    "slug": slug.current\n  }\n': PROPERTY_SLUGS_QUERY_RESULT;
-    '\n  *[_type == "property"\n    && !(status in ["vendido", "alquilado"])\n    && ($operationType == "" || operationType == $operationType)\n    && (count($propertyTypeSlugs) == 0 || propertyType->slug.current in $propertyTypeSlugs)\n    && (count($citySlugs) == 0 || city->slug.current in $citySlugs)\n    && (count($roomsList) == 0 || rooms in $roomsList)\n  ] | order(publishedAt desc)[$start...$end] {\n    _id,\n    title,\n    "slug": slug.current,\n    subtitle,\n    price,\n    currency,\n    operationType,\n    "propertyType": propertyType->name,\n    "city": city->name,\n    rooms,\n    "image": images[0] { asset->{ _id, url, metadata { lqip } } }\n  }\n': PROPERTIES_QUERY_RESULT;
-    '\n  count(*[_type == "property"\n    && !(status in ["vendido", "alquilado"])\n    && ($operationType == "" || operationType == $operationType)\n    && (count($propertyTypeSlugs) == 0 || propertyType->slug.current in $propertyTypeSlugs)\n    && (count($citySlugs) == 0 || city->slug.current in $citySlugs)\n    && (count($roomsList) == 0 || rooms in $roomsList)\n  ])\n': COUNT_QUERY_RESULT;
+    '\n  *[_type == "property" && defined(slug.current)]{\n    "slug": slug.current\n  }\n': PROPERTY_SLUGS_QUERY_RESULT;
+    '\n  *[_type == "property"\n    && defined(slug.current)\n    && !(status in ["vendido", "alquilado"])\n    && ($operationType == "" || operationType == $operationType)\n    && (count($propertyTypeSlugs) == 0 || propertyType->slug.current in $propertyTypeSlugs)\n    && (count($citySlugs) == 0 || city->slug.current in $citySlugs)\n    && (count($roomsList) == 0 || rooms in $roomsList)\n  ] | order(publishedAt desc)[$start...$end] {\n    _id,\n    title,\n    "slug": slug.current,\n    subtitle,\n    price,\n    currency,\n    operationType,\n    "propertyType": propertyType->name,\n    "city": city->name,\n    rooms,\n    "image": images[0] { asset->{ _id, url, metadata { lqip } } }\n  }\n': PROPERTIES_QUERY_RESULT;
+    '\n  count(*[_type == "property"\n    && defined(slug.current)\n    && !(status in ["vendido", "alquilado"])\n    && ($operationType == "" || operationType == $operationType)\n    && (count($propertyTypeSlugs) == 0 || propertyType->slug.current in $propertyTypeSlugs)\n    && (count($citySlugs) == 0 || city->slug.current in $citySlugs)\n    && (count($roomsList) == 0 || rooms in $roomsList)\n  ])\n': COUNT_QUERY_RESULT;
     '*\n  [_type == "property" && featured == true && !(status in ["vendido", "alquilado"])]\n  | order(publishedAt desc)[0...6]\n  {\n    _id,\n    title,\n    "slug": slug.current,\n    subtitle,\n    price,\n    currency,\n    operationType,\n    rooms,\n    "city": city->name,\n    "image": images[0] { asset->{ _id, url, metadata { lqip } } }\n  }': FEATURED_QUERY_RESULT;
     '\n  *[_type == "homePage"][0].sections[]{\n    _key,\n    title,\n    anchorId,\n    content,\n    imagePosition,\n    backgroundColor,\n    images[]{ asset->{ url, metadata { lqip } }, alt }\n  }\n': HOME_SECTIONS_QUERY_RESULT;
     '\n  *[_type == "homePage"][0] {\n    heroHeading,\n    heroImage { asset->{ url, metadata { lqip } } },\n    heroLogo { asset->{ url, metadata { lqip, dimensions } }, alt },\n    featuredPropertiesHeading\n  }\n': HOME_CONTENT_QUERY_RESULT;


### PR DESCRIPTION
## Summary

- **Fix filter URL not updating**: Lifted `useTransition` from `PropertiesFiltersInner` to the stable outer `PropertiesFilters` wrapper. The inner component remounts via `key={searchKey}` when search params change, which orphaned the transition and prevented the browser URL from committing. The outer wrapper persists across remounts, keeping the transition alive.
- **Fix accordion collapse on desktop**: Replaced custom CSS collapse classes (`filters-section--expanded`/`filters-section--collapsed`) with Bootstrap's built-in `collapse`/`collapse show` classes. The custom CSS had a desktop media query that forced `display: flex` on collapsed sections, preventing them from hiding.
- **Fix skeleton layout on desktop**: Rewrote the propiedades `loading.tsx` to use Bootstrap grid classes (`row`/`col-lg-3`/`col-lg-9`) instead of custom CSS grid classes from `PropertiesLayout.css`. The component CSS isn't available during the loading state, causing the skeleton to stack vertically on desktop.
- Remove leftover `console.log` from revalidate route and include updated generated Sanity types.

## Test plan

- [ ] Navigate to `/propiedades`, apply a filter (e.g. Venta), verify the URL updates to include `?operacion=venta`
- [ ] Toggle filter accordion sections on desktop — verify they collapse and expand correctly
- [ ] Reload `/propiedades` and verify the loading skeleton shows the correct two-column layout on desktop
- [ ] Run `pnpm test:e2e` and verify the "filter by operacion updates URL" test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)