### PR TITLE
perf: improve Core Web Vitals (CLS, LCP, INP)

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -22,8 +22,7 @@
     "next": "^16.1.6",
     "next-sanity": "^12.0.15",
     "react": "^19.2.4",
-    "react-dom": "^19.2.4",
-    "sanity": "^5.7.0"
+    "react-dom": "^19.2.4"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.3",

--- a/apps/frontend/src/app/api/revalidate/route.ts
+++ b/apps/frontend/src/app/api/revalidate/route.ts
@@ -1,10 +1,25 @@
-import { revalidateTag } from "next/cache";
+import { revalidatePath, revalidateTag } from "next/cache";
 import { type NextRequest, NextResponse } from "next/server";
 import { parseBody } from "next-sanity/webhook";
 
+type RevalidatePayload = {
+  _type: string;
+  slug?: {
+    current?: string | null;
+  } | null;
+};
+
+const PATHS_BY_TYPE: Record<string, string[]> = {
+  homePage: ["/"],
+  propiedadesPage: ["/propiedades"],
+  siteSettings: ["/", "/propiedades"],
+  seo: ["/", "/propiedades"],
+  property: ["/propiedades"],
+};
+
 export async function POST(req: NextRequest) {
   try {
-    const { isValidSignature, body } = await parseBody<{ _type: string }>(
+    const { isValidSignature, body } = await parseBody<RevalidatePayload>(
       req,
       process.env.SANITY_REVALIDATE_SECRET,
       true,
@@ -21,6 +36,15 @@ export async function POST(req: NextRequest) {
     }
 
     revalidateTag(body._type, "max");
+
+    const paths = PATHS_BY_TYPE[body._type] ?? [];
+    for (const path of paths) {
+      revalidatePath(path);
+    }
+
+    if (body._type === "property" && body.slug?.current) {
+      revalidatePath(`/propiedades/${body.slug.current}`);
+    }
 
     return NextResponse.json({ revalidated: true, tag: body._type });
   } catch (err) {

--- a/apps/frontend/src/app/api/revalidate/route.ts
+++ b/apps/frontend/src/app/api/revalidate/route.ts
@@ -29,8 +29,6 @@ export async function POST(req: NextRequest) {
       return new Response("Invalid signature", { status: 401 });
     }
 
-    console.log("Revalidating tag:", body);
-
     if (!body?._type) {
       return new Response("Bad request", { status: 400 });
     }

--- a/apps/frontend/src/app/page.tsx
+++ b/apps/frontend/src/app/page.tsx
@@ -2,7 +2,9 @@ import type { Metadata } from "next";
 import { Suspense } from "react";
 import { cacheLife, cacheTag } from "next/cache";
 import { defineQuery } from "next-sanity";
+import type { SanityImageSource } from "@sanity/image-url";
 import { sanityFetch } from "@/sanity/lib/live";
+import { urlFor } from "@/sanity/lib/image";
 import {
   getCachedCities,
   getCachedPropertyTypes,
@@ -144,6 +146,16 @@ export default async function Home() {
     ]);
 
   const filterOptions = buildFilterOptions(cities, propertyTypes, roomCounts);
+  const heroImageUrl = urlFor(homeContent!.heroImage! as SanityImageSource)
+    .width(1920)
+    .auto("format")
+    .quality(80)
+    .url();
+  const heroLogoUrl = urlFor(homeContent!.heroLogo! as SanityImageSource)
+    .width(400)
+    .auto("format")
+    .quality(80)
+    .url();
   const organizationJsonLd = organization
     ? {
         "@context": "https://schema.org",
@@ -164,9 +176,9 @@ export default async function Home() {
       <SearchProperties
         filterOptions={filterOptions}
         heroHeading={homeContent!.heroHeading!}
-        heroImageUrl={homeContent!.heroImage!.asset!.url!}
+        heroImageUrl={heroImageUrl}
         heroImageLqip={homeContent!.heroImage!.asset!.metadata?.lqip}
-        heroLogoUrl={homeContent!.heroLogo!.asset!.url!}
+        heroLogoUrl={heroLogoUrl}
         heroLogoAlt={homeContent!.heroLogo!.alt}
       />
       <Suspense

--- a/apps/frontend/src/app/propiedades/loading.tsx
+++ b/apps/frontend/src/app/propiedades/loading.tsx
@@ -8,46 +8,49 @@ export default function PropiedadesLoading() {
       </nav>
       <h1 className="text-center mb-4 fw-bold">Propiedades</h1>
 
-      <div className="properties-layout properties-layout--expanded">
-        <div style={{ gridArea: "filters" }}>
-          <div className="filters-sticky-wrapper">
-            <div className="d-lg-none mb-4 placeholder-glow">
-              <span className="placeholder w-100 d-block" style={{ height: 44 }}></span>
+      <div className="row g-4">
+        {/* Filter sidebar skeleton - desktop only */}
+        <div className="d-none d-lg-block col-lg-3">
+          <div className="bg-light rounded-3 p-3">
+            <div className="placeholder-glow mb-3">
+              <span className="placeholder col-4"></span>
             </div>
-
-            <div className="bg-light rounded-3 p-3">
-              <div className="placeholder-glow mb-3">
-                <span className="placeholder col-4"></span>
-              </div>
-              <div className="placeholder-glow mb-3">
-                <span className="placeholder col-6 d-block mb-2"></span>
-                <span className="placeholder col-8 d-block mb-2"></span>
-                <span className="placeholder col-7 d-block"></span>
-              </div>
-              <div className="placeholder-glow mb-3">
-                <span className="placeholder col-7 d-block mb-2"></span>
-                <span className="placeholder col-9 d-block mb-2"></span>
-                <span className="placeholder col-6 d-block"></span>
-              </div>
-              <div className="placeholder-glow mb-3">
-                <span className="placeholder col-5 d-block mb-2"></span>
-                <span className="placeholder col-8 d-block mb-2"></span>
-                <span className="placeholder col-6 d-block"></span>
-              </div>
-              <div className="placeholder-glow mb-4">
-                <span className="placeholder col-4 d-block mb-2"></span>
-                <span className="placeholder col-7 d-block mb-2"></span>
-                <span className="placeholder col-6 d-block"></span>
-              </div>
-              <div className="placeholder-glow">
-                <span className="placeholder w-100 d-block mb-2" style={{ height: 40 }}></span>
-                <span className="placeholder w-100 d-block" style={{ height: 40 }}></span>
-              </div>
+            <div className="placeholder-glow mb-3">
+              <span className="placeholder col-6 d-block mb-2"></span>
+              <span className="placeholder col-8 d-block mb-2"></span>
+              <span className="placeholder col-7 d-block"></span>
+            </div>
+            <div className="placeholder-glow mb-3">
+              <span className="placeholder col-7 d-block mb-2"></span>
+              <span className="placeholder col-9 d-block mb-2"></span>
+              <span className="placeholder col-6 d-block"></span>
+            </div>
+            <div className="placeholder-glow mb-3">
+              <span className="placeholder col-5 d-block mb-2"></span>
+              <span className="placeholder col-8 d-block mb-2"></span>
+              <span className="placeholder col-6 d-block"></span>
+            </div>
+            <div className="placeholder-glow mb-4">
+              <span className="placeholder col-4 d-block mb-2"></span>
+              <span className="placeholder col-7 d-block mb-2"></span>
+              <span className="placeholder col-6 d-block"></span>
+            </div>
+            <div className="placeholder-glow">
+              <span className="placeholder w-100 d-block mb-2" style={{ height: 40 }}></span>
+              <span className="placeholder w-100 d-block" style={{ height: 40 }}></span>
             </div>
           </div>
         </div>
 
-        <div style={{ gridArea: "main", minWidth: 0 }}>
+        {/* Mobile filter toggle skeleton */}
+        <div className="d-lg-none col-12">
+          <div className="placeholder-glow mb-4">
+            <span className="placeholder w-100 d-block" style={{ height: 44 }}></span>
+          </div>
+        </div>
+
+        {/* Main content skeleton */}
+        <div className="col-12 col-lg-9">
           <div className="d-flex flex-wrap gap-2 mb-3 placeholder-glow">
             <span className="placeholder rounded-pill" style={{ width: 80, height: 26 }}></span>
             <span className="placeholder rounded-pill" style={{ width: 110, height: 26 }}></span>

--- a/apps/frontend/src/components/CircularCarousel.tsx
+++ b/apps/frontend/src/components/CircularCarousel.tsx
@@ -47,6 +47,7 @@ export default function CircularCarousel({ images, id }: CircularCarouselProps) 
                 fill
                 sizes="300px"
                 className="object-fit-cover"
+                loading="lazy"
                 {...(image.asset?.metadata?.lqip
                   ? {
                       placeholder: "blur" as const,

--- a/apps/frontend/src/components/ImageCarousel.css
+++ b/apps/frontend/src/components/ImageCarousel.css
@@ -1,15 +1,4 @@
 .carousel-image-container {
-  height: 250px;
-}
-
-@media (min-width: 576px) {
-  .carousel-image-container {
-    height: 350px;
-  }
-}
-
-@media (min-width: 992px) {
-  .carousel-image-container {
-    height: 500px;
-  }
+  aspect-ratio: 12/5;
+  width: 100%;
 }

--- a/apps/frontend/src/components/ImageCarousel.tsx
+++ b/apps/frontend/src/components/ImageCarousel.tsx
@@ -1,10 +1,10 @@
-'use client';
+"use client";
 
-import { useEffect, useState } from 'react';
-import { urlFor } from '@/sanity/lib/image';
-import type { SanityImageSource } from '@sanity/image-url';
-import Image from 'next/image';
-import './ImageCarousel.css';
+import { urlFor } from "@/sanity/lib/image";
+import type { SanityImageSource } from "@sanity/image-url";
+import Image from "next/image";
+import { useReducedMotion } from "@/hooks/useReducedMotion";
+import "./ImageCarousel.css";
 
 interface CarouselImage {
   asset?: SanityImageSource | null;
@@ -17,19 +17,7 @@ interface ImageCarouselProps {
 }
 
 export default function ImageCarousel({ images, title }: ImageCarouselProps) {
-  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
-
-  useEffect(() => {
-    const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
-    const updatePreference = () => setPrefersReducedMotion(mediaQuery.matches);
-    updatePreference();
-    if (mediaQuery.addEventListener) {
-      mediaQuery.addEventListener('change', updatePreference);
-      return () => mediaQuery.removeEventListener('change', updatePreference);
-    }
-    mediaQuery.addListener(updatePreference);
-    return () => mediaQuery.removeListener(updatePreference);
-  }, []);
+  const prefersReducedMotion = useReducedMotion();
 
   if (images.length === 0) {
     return (

--- a/apps/frontend/src/components/PropertiesFilters.css
+++ b/apps/frontend/src/components/PropertiesFilters.css
@@ -3,13 +3,3 @@
   flex-direction: column;
   gap: 0.5rem;
 }
-
-.filters-section--collapsed {
-  display: none;
-}
-
-@media (min-width: 992px) {
-  .filters-section--collapsed {
-    display: flex;
-  }
-}

--- a/apps/frontend/src/components/PropertiesFilters.tsx
+++ b/apps/frontend/src/components/PropertiesFilters.tsx
@@ -19,6 +19,8 @@ type SearchParams = ReturnType<typeof useSearchParams>;
 
 interface PropertiesFiltersInnerProps extends PropertiesFiltersProps {
   searchParams: SearchParams;
+  isPending: boolean;
+  startTransition: (callback: () => void) => void;
 }
 
 function PropertiesFiltersInner({
@@ -29,21 +31,22 @@ function PropertiesFiltersInner({
   onToggleCollapse,
   onFilteringChange,
   searchParams,
+  isPending,
+  startTransition,
 }: PropertiesFiltersInnerProps) {
   const router = useRouter();
   const [isOpenMobile, setIsOpenMobile] = useState(false);
-  const [isPending, startTransition] = useTransition();
   const initialOperacion = searchParams.get("operacion") || "";
   const initialPropiedad = parseMultiple(searchParams.get("propiedad"));
   const initialLocalidad = parseMultiple(searchParams.get("localidad"));
   const initialDormitorios = parseMultiple(searchParams.get("dormitorios"));
 
-  const [expandedSections, setExpandedSections] = useState(() => ({
-    operacion: Boolean(initialOperacion),
-    propiedad: initialPropiedad.length > 0,
-    localidad: initialLocalidad.length > 0,
+  const [expandedSections, setExpandedSections] = useState({
+    operacion: true,
+    propiedad: true,
+    localidad: true,
     dormitorios: initialDormitorios.length > 0,
-  }));
+  });
 
   const [operacion, setOperacion] = useState(initialOperacion);
   const [propiedad, setPropiedad] = useState<string[]>(initialPropiedad);
@@ -51,8 +54,10 @@ function PropertiesFiltersInner({
   const [dormitorios, setDormitorios] = useState<string[]>(initialDormitorios);
 
   const activeFilterCount =
-    (operacion ? 1 : 0) + propiedad.length + localidad.length + dormitorios.length;
-
+    (operacion ? 1 : 0) +
+    propiedad.length +
+    localidad.length +
+    dormitorios.length;
 
   const toggleSection = (key: keyof typeof expandedSections) => {
     setExpandedSections((prev) => ({
@@ -67,11 +72,10 @@ function PropertiesFiltersInner({
     }
   }, [isPending, onFilteringChange]);
 
-
   const toggleArrayValue = (
     arr: string[],
     value: string,
-    setter: (val: string[]) => void
+    setter: (val: string[]) => void,
   ) => {
     if (arr.includes(value)) {
       setter(arr.filter((v) => v !== value));
@@ -86,7 +90,8 @@ function PropertiesFiltersInner({
     if (operacion) params.set("operacion", operacion);
     if (propiedad.length > 0) params.set("propiedad", propiedad.join(","));
     if (localidad.length > 0) params.set("localidad", localidad.join(","));
-    if (dormitorios.length > 0) params.set("dormitorios", dormitorios.join(","));
+    if (dormitorios.length > 0)
+      params.set("dormitorios", dormitorios.join(","));
 
     const queryString = params.toString();
     startTransition(() => {
@@ -117,12 +122,16 @@ function PropertiesFiltersInner({
           aria-expanded={expandedSections.operacion}
           aria-controls="filters-operacion"
         >
-          <span className="fw-semibold small text-uppercase text-muted">Operación</span>
-          <i className={`bi bi-chevron-${expandedSections.operacion ? "up" : "down"}`}></i>
+          <span className="fw-semibold small text-uppercase text-muted">
+            Operación
+          </span>
+          <i
+            className={`bi bi-chevron-${expandedSections.operacion ? "up" : "down"}`}
+          ></i>
         </button>
         <div
           id="filters-operacion"
-          className={`filters-section ${expandedSections.operacion ? "filters-section--expanded mt-2" : "filters-section--collapsed"}`}
+          className={`filters-section collapse${expandedSections.operacion ? " show mt-2" : ""}`}
         >
           <div className="form-check">
             <input
@@ -175,12 +184,16 @@ function PropertiesFiltersInner({
           aria-expanded={expandedSections.propiedad}
           aria-controls="filters-propiedad"
         >
-          <span className="fw-semibold small text-uppercase text-muted">Tipo de propiedad</span>
-          <i className={`bi bi-chevron-${expandedSections.propiedad ? "up" : "down"}`}></i>
+          <span className="fw-semibold small text-uppercase text-muted">
+            Tipo de propiedad
+          </span>
+          <i
+            className={`bi bi-chevron-${expandedSections.propiedad ? "up" : "down"}`}
+          ></i>
         </button>
         <div
           id="filters-propiedad"
-          className={`filters-section ${expandedSections.propiedad ? "filters-section--expanded mt-2" : "filters-section--collapsed"}`}
+          className={`filters-section collapse${expandedSections.propiedad ? " show mt-2" : ""}`}
         >
           {propertyTypes.map((type) => (
             <div key={type.slug} className="form-check">
@@ -189,9 +202,14 @@ function PropertiesFiltersInner({
                 type="checkbox"
                 id={`propiedad-${type.slug}`}
                 checked={propiedad.includes(type.slug)}
-                onChange={() => toggleArrayValue(propiedad, type.slug, setPropiedad)}
+                onChange={() =>
+                  toggleArrayValue(propiedad, type.slug, setPropiedad)
+                }
               />
-              <label className="form-check-label" htmlFor={`propiedad-${type.slug}`}>
+              <label
+                className="form-check-label"
+                htmlFor={`propiedad-${type.slug}`}
+              >
                 {type.name}
               </label>
             </div>
@@ -211,12 +229,16 @@ function PropertiesFiltersInner({
           aria-expanded={expandedSections.localidad}
           aria-controls="filters-localidad"
         >
-          <span className="fw-semibold small text-uppercase text-muted">Localidad</span>
-          <i className={`bi bi-chevron-${expandedSections.localidad ? "up" : "down"}`}></i>
+          <span className="fw-semibold small text-uppercase text-muted">
+            Localidad
+          </span>
+          <i
+            className={`bi bi-chevron-${expandedSections.localidad ? "up" : "down"}`}
+          ></i>
         </button>
         <div
           id="filters-localidad"
-          className={`filters-section ${expandedSections.localidad ? "filters-section--expanded mt-2" : "filters-section--collapsed"}`}
+          className={`filters-section collapse${expandedSections.localidad ? " show mt-2" : ""}`}
           style={{ maxHeight: 200, overflowY: "auto" }}
         >
           {cities.map((city) => (
@@ -226,9 +248,14 @@ function PropertiesFiltersInner({
                 type="checkbox"
                 id={`localidad-${city.slug}`}
                 checked={localidad.includes(city.slug)}
-                onChange={() => toggleArrayValue(localidad, city.slug, setLocalidad)}
+                onChange={() =>
+                  toggleArrayValue(localidad, city.slug, setLocalidad)
+                }
               />
-              <label className="form-check-label" htmlFor={`localidad-${city.slug}`}>
+              <label
+                className="form-check-label"
+                htmlFor={`localidad-${city.slug}`}
+              >
                 {city.name}
               </label>
             </div>
@@ -248,12 +275,16 @@ function PropertiesFiltersInner({
           aria-expanded={expandedSections.dormitorios}
           aria-controls="filters-dormitorios"
         >
-          <span className="fw-semibold small text-uppercase text-muted">Dormitorios</span>
-          <i className={`bi bi-chevron-${expandedSections.dormitorios ? "up" : "down"}`}></i>
+          <span className="fw-semibold small text-uppercase text-muted">
+            Dormitorios
+          </span>
+          <i
+            className={`bi bi-chevron-${expandedSections.dormitorios ? "up" : "down"}`}
+          ></i>
         </button>
         <div
           id="filters-dormitorios"
-          className={`filters-section ${expandedSections.dormitorios ? "filters-section--expanded mt-2" : "filters-section--collapsed"}`}
+          className={`filters-section collapse${expandedSections.dormitorios ? " show mt-2" : ""}`}
         >
           {roomCounts.map((count) => (
             <div key={count} className="form-check">
@@ -263,10 +294,17 @@ function PropertiesFiltersInner({
                 id={`dormitorios-${count}`}
                 checked={dormitorios.includes(count.toString())}
                 onChange={() =>
-                  toggleArrayValue(dormitorios, count.toString(), setDormitorios)
+                  toggleArrayValue(
+                    dormitorios,
+                    count.toString(),
+                    setDormitorios,
+                  )
                 }
               />
-              <label className="form-check-label" htmlFor={`dormitorios-${count}`}>
+              <label
+                className="form-check-label"
+                htmlFor={`dormitorios-${count}`}
+              >
                 {count} {count === 1 ? "dormitorio" : "dormitorios"}
               </label>
             </div>
@@ -371,9 +409,7 @@ function PropertiesFiltersInner({
           </div>
 
           {/* Actual filter form */}
-          <div className="bg-light rounded-3 p-3">
-            {filterForm}
-          </div>
+          <div className="bg-light rounded-3 p-3">{filterForm}</div>
         </div>
       )}
     </>
@@ -383,8 +419,15 @@ function PropertiesFiltersInner({
 export default function PropertiesFilters(props: PropertiesFiltersProps) {
   const searchParams = useSearchParams();
   const searchKey = searchParams.toString();
+  const [isPending, startTransition] = useTransition();
 
   return (
-    <PropertiesFiltersInner key={searchKey} searchParams={searchParams} {...props} />
+    <PropertiesFiltersInner
+      key={searchKey}
+      searchParams={searchParams}
+      isPending={isPending}
+      startTransition={startTransition}
+      {...props}
+    />
   );
 }

--- a/apps/frontend/src/components/PropertiesGrid.tsx
+++ b/apps/frontend/src/components/PropertiesGrid.tsx
@@ -25,7 +25,7 @@ export default function PropertiesGrid({ properties }: PropertiesGridProps) {
 
   return (
     <div className="row g-4">
-      {properties.map((property) => (
+      {properties.map((property, index) => (
         <div
           key={property._id}
           className="col-12 col-sm-6 col-xl-4 d-flex justify-content-center"
@@ -41,6 +41,7 @@ export default function PropertiesGrid({ properties }: PropertiesGridProps) {
             lqip={property.lqip}
             rooms={property.rooms}
             city={property.city}
+            priority={index === 0}
           />
         </div>
       ))}

--- a/apps/frontend/src/components/PropertyCard.tsx
+++ b/apps/frontend/src/components/PropertyCard.tsx
@@ -14,6 +14,7 @@ interface PropertyCardProps {
   lqip?: string | null;
   rooms?: number | null;
   city?: string | null;
+  priority?: boolean;
 }
 
 export default function PropertyCard({
@@ -27,6 +28,7 @@ export default function PropertyCard({
   lqip,
   rooms,
   city,
+  priority,
 }: PropertyCardProps) {
   const imageUrl = image
     ? urlFor(image).height(220).width(400).quality(80).auto("format").url()
@@ -40,7 +42,7 @@ export default function PropertyCard({
         className="card shadow-sm rounded-4 border-0 h-100"
         style={{ maxWidth: 400 }}
       >
-        <div className="position-relative">
+        <div className="position-relative" style={{ aspectRatio: "400/220" }}>
           <Image
             src={imageUrl}
             alt={title || "Property Image"}
@@ -48,6 +50,7 @@ export default function PropertyCard({
             height={220}
             sizes="(min-width: 992px) 33vw, (min-width: 768px) 50vw, 100vw"
             className="card-img-top rounded-top-4 object-fit-cover"
+            priority={priority}
             {...(lqip ? { placeholder: "blur" as const, blurDataURL: lqip } : {})}
           />
           {operationType && (

--- a/apps/frontend/src/components/TextImageSection.css
+++ b/apps/frontend/src/components/TextImageSection.css
@@ -41,8 +41,8 @@
 
 /* Circular image container */
 .section-circle-image {
+  aspect-ratio: 1/1;
   width: 200px;
-  height: 200px;
   position: relative;
 }
 
@@ -53,7 +53,6 @@
 @media (min-width: 768px) {
   .section-circle-image {
     width: 300px;
-    height: 300px;
   }
 }
 

--- a/apps/frontend/src/components/TextImageSection.tsx
+++ b/apps/frontend/src/components/TextImageSection.tsx
@@ -62,6 +62,7 @@ export default function TextImageSection({
                   fill
                   sizes="300px"
                   className="object-fit-cover"
+                  loading="lazy"
                   {...(primaryImage?.asset?.metadata?.lqip
                     ? {
                         placeholder: "blur" as const,

--- a/apps/frontend/src/hooks/useReducedMotion.ts
+++ b/apps/frontend/src/hooks/useReducedMotion.ts
@@ -1,0 +1,19 @@
+import { useSyncExternalStore } from "react";
+
+function getSnapshot() {
+  return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+}
+
+function getServerSnapshot() {
+  return false;
+}
+
+function subscribe(callback: () => void) {
+  const mediaQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
+  mediaQuery.addEventListener("change", callback);
+  return () => mediaQuery.removeEventListener("change", callback);
+}
+
+export function useReducedMotion() {
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+}

--- a/apps/frontend/src/sanity/lib/structure.ts
+++ b/apps/frontend/src/sanity/lib/structure.ts
@@ -1,7 +1,0 @@
-import type { StructureResolver } from 'sanity/structure'
-
-// https://www.sanity.io/docs/structure-builder-cheat-sheet
-export const structure: StructureResolver = (S) =>
-  S.list()
-    .title('Content')
-    .items(S.documentTypeListItems())

--- a/apps/frontend/src/sanity/queries/homePage.ts
+++ b/apps/frontend/src/sanity/queries/homePage.ts
@@ -25,8 +25,8 @@ export async function getCachedHomeSections() {
 const HOME_CONTENT_QUERY = defineQuery(`
   *[_type == "homePage"][0] {
     heroHeading,
-    heroImage { asset->{ url, metadata { lqip } } },
-    heroLogo { asset->{ url, metadata { lqip, dimensions } }, alt },
+    heroImage { asset->{ _id, url, metadata { lqip, dimensions } } },
+    heroLogo { asset->{ _id, url, metadata { lqip, dimensions } }, alt },
     featuredPropertiesHeading
   }
 `);

--- a/apps/frontend/src/sanity/types.ts
+++ b/apps/frontend/src/sanity/types.ts
@@ -473,14 +473,14 @@ export type PROPERTY_QUERY_RESULT = {
 
 // Source: ../frontend/src/app/propiedades/[slug]/page.tsx
 // Variable: PROPERTY_SLUGS_QUERY
-// Query: *[_type == "property" && defined(slug.current) && !(status in ["vendido", "alquilado"])]{    "slug": slug.current  }
+// Query: *[_type == "property" && defined(slug.current)]{    "slug": slug.current  }
 export type PROPERTY_SLUGS_QUERY_RESULT = Array<{
   slug: string | null;
 }>;
 
 // Source: ../frontend/src/app/propiedades/page.tsx
 // Variable: PROPERTIES_QUERY
-// Query: *[_type == "property"    && !(status in ["vendido", "alquilado"])    && ($operationType == "" || operationType == $operationType)    && (count($propertyTypeSlugs) == 0 || propertyType->slug.current in $propertyTypeSlugs)    && (count($citySlugs) == 0 || city->slug.current in $citySlugs)    && (count($roomsList) == 0 || rooms in $roomsList)  ] | order(publishedAt desc)[$start...$end] {    _id,    title,    "slug": slug.current,    subtitle,    price,    currency,    operationType,    "propertyType": propertyType->name,    "city": city->name,    rooms,    "image": images[0] { asset->{ _id, url, metadata { lqip } } }  }
+// Query: *[_type == "property"    && defined(slug.current)    && !(status in ["vendido", "alquilado"])    && ($operationType == "" || operationType == $operationType)    && (count($propertyTypeSlugs) == 0 || propertyType->slug.current in $propertyTypeSlugs)    && (count($citySlugs) == 0 || city->slug.current in $citySlugs)    && (count($roomsList) == 0 || rooms in $roomsList)  ] | order(publishedAt desc)[$start...$end] {    _id,    title,    "slug": slug.current,    subtitle,    price,    currency,    operationType,    "propertyType": propertyType->name,    "city": city->name,    rooms,    "image": images[0] { asset->{ _id, url, metadata { lqip } } }  }
 export type PROPERTIES_QUERY_RESULT = Array<{
   _id: string;
   title: string | null;
@@ -505,7 +505,7 @@ export type PROPERTIES_QUERY_RESULT = Array<{
 
 // Source: ../frontend/src/app/propiedades/page.tsx
 // Variable: COUNT_QUERY
-// Query: count(*[_type == "property"    && !(status in ["vendido", "alquilado"])    && ($operationType == "" || operationType == $operationType)    && (count($propertyTypeSlugs) == 0 || propertyType->slug.current in $propertyTypeSlugs)    && (count($citySlugs) == 0 || city->slug.current in $citySlugs)    && (count($roomsList) == 0 || rooms in $roomsList)  ])
+// Query: count(*[_type == "property"    && defined(slug.current)    && !(status in ["vendido", "alquilado"])    && ($operationType == "" || operationType == $operationType)    && (count($propertyTypeSlugs) == 0 || propertyType->slug.current in $propertyTypeSlugs)    && (count($citySlugs) == 0 || city->slug.current in $citySlugs)    && (count($roomsList) == 0 || rooms in $roomsList)  ])
 export type COUNT_QUERY_RESULT = number;
 
 // Source: ../frontend/src/components/FeaturedProperties.tsx
@@ -756,9 +756,9 @@ declare module "@sanity/client" {
   interface SanityQueries {
     '\n  *[_type == "siteSettings"][0].address\n': MAP_ADDRESS_QUERY_RESULT;
     '\n  *[_type == "property" && slug.current == $slug][0]\n  {\n    title,\n    subtitle,\n    address,\n    description,\n    price,\n    "propertyType": propertyType->name,\n    operationType,\n    status,\n    currency,\n    "city": city->name,\n    "images": images[] { asset->{ _id, url, metadata { lqip } } },\n    "ogImage": images[0],\n    seo {\n      metaTitle,\n      metaDescription,\n      ogImage { asset->{ url } },\n      noIndex\n    }\n  }\n': PROPERTY_QUERY_RESULT;
-    '\n  *[_type == "property" && defined(slug.current) && !(status in ["vendido", "alquilado"])]{\n    "slug": slug.current\n  }\n': PROPERTY_SLUGS_QUERY_RESULT;
-    '\n  *[_type == "property"\n    && !(status in ["vendido", "alquilado"])\n    && ($operationType == "" || operationType == $operationType)\n    && (count($propertyTypeSlugs) == 0 || propertyType->slug.current in $propertyTypeSlugs)\n    && (count($citySlugs) == 0 || city->slug.current in $citySlugs)\n    && (count($roomsList) == 0 || rooms in $roomsList)\n  ] | order(publishedAt desc)[$start...$end] {\n    _id,\n    title,\n    "slug": slug.current,\n    subtitle,\n    price,\n    currency,\n    operationType,\n    "propertyType": propertyType->name,\n    "city": city->name,\n    rooms,\n    "image": images[0] { asset->{ _id, url, metadata { lqip } } }\n  }\n': PROPERTIES_QUERY_RESULT;
-    '\n  count(*[_type == "property"\n    && !(status in ["vendido", "alquilado"])\n    && ($operationType == "" || operationType == $operationType)\n    && (count($propertyTypeSlugs) == 0 || propertyType->slug.current in $propertyTypeSlugs)\n    && (count($citySlugs) == 0 || city->slug.current in $citySlugs)\n    && (count($roomsList) == 0 || rooms in $roomsList)\n  ])\n': COUNT_QUERY_RESULT;
+    '\n  *[_type == "property" && defined(slug.current)]{\n    "slug": slug.current\n  }\n': PROPERTY_SLUGS_QUERY_RESULT;
+    '\n  *[_type == "property"\n    && defined(slug.current)\n    && !(status in ["vendido", "alquilado"])\n    && ($operationType == "" || operationType == $operationType)\n    && (count($propertyTypeSlugs) == 0 || propertyType->slug.current in $propertyTypeSlugs)\n    && (count($citySlugs) == 0 || city->slug.current in $citySlugs)\n    && (count($roomsList) == 0 || rooms in $roomsList)\n  ] | order(publishedAt desc)[$start...$end] {\n    _id,\n    title,\n    "slug": slug.current,\n    subtitle,\n    price,\n    currency,\n    operationType,\n    "propertyType": propertyType->name,\n    "city": city->name,\n    rooms,\n    "image": images[0] { asset->{ _id, url, metadata { lqip } } }\n  }\n': PROPERTIES_QUERY_RESULT;
+    '\n  count(*[_type == "property"\n    && defined(slug.current)\n    && !(status in ["vendido", "alquilado"])\n    && ($operationType == "" || operationType == $operationType)\n    && (count($propertyTypeSlugs) == 0 || propertyType->slug.current in $propertyTypeSlugs)\n    && (count($citySlugs) == 0 || city->slug.current in $citySlugs)\n    && (count($roomsList) == 0 || rooms in $roomsList)\n  ])\n': COUNT_QUERY_RESULT;
     '*\n  [_type == "property" && featured == true && !(status in ["vendido", "alquilado"])]\n  | order(publishedAt desc)[0...6]\n  {\n    _id,\n    title,\n    "slug": slug.current,\n    subtitle,\n    price,\n    currency,\n    operationType,\n    rooms,\n    "city": city->name,\n    "image": images[0] { asset->{ _id, url, metadata { lqip } } }\n  }': FEATURED_QUERY_RESULT;
     '\n  *[_type == "homePage"][0].sections[]{\n    _key,\n    title,\n    anchorId,\n    content,\n    imagePosition,\n    backgroundColor,\n    images[]{ asset->{ url, metadata { lqip } }, alt }\n  }\n': HOME_SECTIONS_QUERY_RESULT;
     '\n  *[_type == "homePage"][0] {\n    heroHeading,\n    heroImage { asset->{ url, metadata { lqip } } },\n    heroLogo { asset->{ url, metadata { lqip, dimensions } }, alt },\n    featuredPropertiesHeading\n  }\n': HOME_CONTENT_QUERY_RESULT;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,16 +36,13 @@ importers:
         version: 16.1.6(@babel/core@7.28.6)(@playwright/test@1.58.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next-sanity:
         specifier: ^12.0.15
-        version: 12.0.15(@emotion/is-prop-valid@1.4.0)(@sanity/client@7.14.1)(@sanity/types@5.7.0(@types/react@19.2.10))(next@16.1.6(@babel/core@7.28.6)(@playwright/test@1.58.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-is@19.2.4)(react@19.2.4)(sanity@5.7.0(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.0.1)(@types/node@25.1.0)(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(babel-plugin-react-compiler@1.0.0)(jiti@2.6.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-components@6.3.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(tsx@4.21.0)(typescript@5.9.3)(vitest@3.2.4(@types/node@25.1.0)(jiti@2.6.1)(jsdom@26.1.0)(tsx@4.21.0)(yaml@2.8.2))(yaml@2.8.2))(styled-components@6.3.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)
+        version: 12.0.15(@emotion/is-prop-valid@1.4.0)(@sanity/client@7.14.1)(@sanity/types@5.7.0(@types/react@19.2.10))(next@16.1.6(@babel/core@7.28.6)(@playwright/test@1.58.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-is@19.2.4)(react@19.2.4)(sanity@5.7.0(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.0.1)(@types/node@25.1.0)(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(babel-plugin-react-compiler@1.0.0)(jiti@2.6.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-components@6.3.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(tsx@4.21.0)(typescript@5.9.3)(vitest@3.2.4(@types/node@25.1.0)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@2.0.1))(tsx@4.21.0)(yaml@2.8.2))(yaml@2.8.2))(styled-components@6.3.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)
       react:
         specifier: ^19.2.4
         version: 19.2.4
       react-dom:
         specifier: ^19.2.4
         version: 19.2.4(react@19.2.4)
-      sanity:
-        specifier: ^5.7.0
-        version: 5.7.0(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.0.1)(@types/node@25.1.0)(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(babel-plugin-react-compiler@1.0.0)(jiti@2.6.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-components@6.3.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(tsx@4.21.0)(typescript@5.9.3)(vitest@3.2.4(@types/node@25.1.0)(jiti@2.6.1)(jsdom@26.1.0)(tsx@4.21.0)(yaml@2.8.2))(yaml@2.8.2)
     devDependencies:
       '@eslint/eslintrc':
         specifier: ^3.3.3
@@ -94,7 +91,7 @@ importers:
         version: 3.7.4(react@19.2.4)
       '@sanity/vision':
         specifier: ^5.7.0
-        version: 5.7.0(@babel/runtime@7.28.6)(@codemirror/lint@6.9.3)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.4.0)(codemirror@6.0.2)(react-dom@19.2.4(react@19.2.4))(react-is@19.2.4)(react@19.2.4)(sanity@5.7.0(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.0.1)(@types/node@25.1.0)(@types/react@19.2.10)(babel-plugin-react-compiler@1.0.0)(jiti@2.6.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-components@6.3.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(tsx@4.21.0)(typescript@5.9.3)(vitest@3.2.4(@types/node@25.1.0)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@2.0.1))(tsx@4.21.0)(yaml@2.8.2))(yaml@2.8.2))(styled-components@6.3.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+        version: 5.7.0(@babel/runtime@7.28.6)(@codemirror/lint@6.9.3)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.4.0)(codemirror@6.0.2)(react-dom@19.2.4(react@19.2.4))(react-is@19.2.4)(react@19.2.4)(sanity@5.7.0(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.0.1)(@types/node@25.1.0)(@types/react@19.2.10)(babel-plugin-react-compiler@1.0.0)(jiti@2.6.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-components@6.3.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(tsx@4.21.0)(typescript@5.9.3)(vitest@3.2.4(@types/node@25.1.0)(jiti@2.6.1)(jsdom@26.1.0)(tsx@4.21.0)(yaml@2.8.2))(yaml@2.8.2))(styled-components@6.3.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       react:
         specifier: ^19.2.4
         version: 19.2.4
@@ -103,7 +100,7 @@ importers:
         version: 19.2.4(react@19.2.4)
       sanity:
         specifier: ^5.7.0
-        version: 5.7.0(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.0.1)(@types/node@25.1.0)(@types/react@19.2.10)(babel-plugin-react-compiler@1.0.0)(jiti@2.6.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-components@6.3.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(tsx@4.21.0)(typescript@5.9.3)(vitest@3.2.4(@types/node@25.1.0)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@2.0.1))(tsx@4.21.0)(yaml@2.8.2))(yaml@2.8.2)
+        version: 5.7.0(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.0.1)(@types/node@25.1.0)(@types/react@19.2.10)(babel-plugin-react-compiler@1.0.0)(jiti@2.6.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-components@6.3.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(tsx@4.21.0)(typescript@5.9.3)(vitest@3.2.4(@types/node@25.1.0)(jiti@2.6.1)(jsdom@26.1.0)(tsx@4.21.0)(yaml@2.8.2))(yaml@2.8.2)
       styled-components:
         specifier: ^6.3.8
         version: 6.3.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -7937,22 +7934,7 @@ snapshots:
       - utf-8-validate
       - yaml
 
-  '@sanity/cli-test@0.0.2-alpha.7(@oclif/core@4.8.0)(@sanity/cli-core@0.1.0-alpha.8(@noble/hashes@2.0.1)(@types/node@25.1.0)(@types/react@19.2.10)(jiti@2.6.1)(yaml@2.8.2))(@sanity/client@7.14.1(debug@4.4.3))(vitest@3.2.4(@types/node@25.1.0)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@2.0.1))(tsx@4.21.0)(yaml@2.8.2))':
-    dependencies:
-      '@oclif/core': 4.8.0
-      '@sanity/cli-core': 0.1.0-alpha.8(@noble/hashes@2.0.1)(@types/node@25.1.0)(@types/react@19.2.10)(jiti@2.6.1)(yaml@2.8.2)
-      '@sanity/client': 7.14.1(debug@4.4.3)
-      '@swc/core': 1.15.11
-      ansis: 4.2.0
-      esbuild: 0.27.2
-      nock: 14.0.10
-      ora: 9.1.0
-      tinyglobby: 0.2.15
-      vitest: 3.2.4(@types/node@25.1.0)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@2.0.1))(tsx@4.21.0)(yaml@2.8.2)
-    transitivePeerDependencies:
-      - '@swc/helpers'
-
-  '@sanity/cli-test@0.0.2-alpha.7(@oclif/core@4.8.0)(@sanity/cli-core@0.1.0-alpha.8(@noble/hashes@2.0.1)(@types/node@25.1.0)(@types/react@19.2.10)(jiti@2.6.1)(yaml@2.8.2))(@sanity/client@7.14.1)(vitest@3.2.4(@types/node@25.1.0)(jiti@2.6.1)(jsdom@26.1.0)(tsx@4.21.0)(yaml@2.8.2))':
+  '@sanity/cli-test@0.0.2-alpha.7(@oclif/core@4.8.0)(@sanity/cli-core@0.1.0-alpha.8(@noble/hashes@2.0.1)(@types/node@25.1.0)(@types/react@19.2.10)(jiti@2.6.1)(yaml@2.8.2))(@sanity/client@7.14.1(debug@4.4.3))(vitest@3.2.4(@types/node@25.1.0)(jiti@2.6.1)(jsdom@26.1.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@oclif/core': 4.8.0
       '@sanity/cli-core': 0.1.0-alpha.8(@noble/hashes@2.0.1)(@types/node@25.1.0)(@types/react@19.2.10)(jiti@2.6.1)(yaml@2.8.2)
@@ -7964,6 +7946,21 @@ snapshots:
       ora: 9.1.0
       tinyglobby: 0.2.15
       vitest: 3.2.4(@types/node@25.1.0)(jiti@2.6.1)(jsdom@26.1.0)(tsx@4.21.0)(yaml@2.8.2)
+    transitivePeerDependencies:
+      - '@swc/helpers'
+
+  '@sanity/cli-test@0.0.2-alpha.7(@oclif/core@4.8.0)(@sanity/cli-core@0.1.0-alpha.8(@noble/hashes@2.0.1)(@types/node@25.1.0)(@types/react@19.2.10)(jiti@2.6.1)(yaml@2.8.2))(@sanity/client@7.14.1)(vitest@3.2.4(@types/node@25.1.0)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@2.0.1))(tsx@4.21.0)(yaml@2.8.2))':
+    dependencies:
+      '@oclif/core': 4.8.0
+      '@sanity/cli-core': 0.1.0-alpha.8(@noble/hashes@2.0.1)(@types/node@25.1.0)(@types/react@19.2.10)(jiti@2.6.1)(yaml@2.8.2)
+      '@sanity/client': 7.14.1(debug@4.4.3)
+      '@swc/core': 1.15.11
+      ansis: 4.2.0
+      esbuild: 0.27.2
+      nock: 14.0.10
+      ora: 9.1.0
+      tinyglobby: 0.2.15
+      vitest: 3.2.4(@types/node@25.1.0)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@2.0.1))(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - '@swc/helpers'
 
@@ -8159,7 +8156,7 @@ snapshots:
       - utf-8-validate
       - yaml
 
-  '@sanity/insert-menu@3.0.3(@emotion/is-prop-valid@1.4.0)(@sanity/types@5.7.0(@types/react@19.2.10))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-components@6.3.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
+  '@sanity/insert-menu@3.0.3(@emotion/is-prop-valid@1.4.0)(@sanity/types@5.7.0(@types/react@19.2.10)(debug@4.4.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-components@6.3.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
     dependencies:
       '@sanity/icons': 3.7.4(react@19.2.4)
       '@sanity/types': 5.7.0(@types/react@19.2.10)(debug@4.4.3)
@@ -8194,7 +8191,7 @@ snapshots:
       '@oclif/core': 4.8.0
       '@oclif/plugin-help': 6.2.37
       '@sanity/cli-core': 0.1.0-alpha.8(@noble/hashes@2.0.1)(@types/node@25.1.0)(@types/react@19.2.10)(jiti@2.6.1)(yaml@2.8.2)
-      '@sanity/cli-test': 0.0.2-alpha.7(@oclif/core@4.8.0)(@sanity/cli-core@0.1.0-alpha.8(@noble/hashes@2.0.1)(@types/node@25.1.0)(@types/react@19.2.10)(jiti@2.6.1)(yaml@2.8.2))(@sanity/client@7.14.1)(vitest@3.2.4(@types/node@25.1.0)(jiti@2.6.1)(jsdom@26.1.0)(tsx@4.21.0)(yaml@2.8.2))
+      '@sanity/cli-test': 0.0.2-alpha.7(@oclif/core@4.8.0)(@sanity/cli-core@0.1.0-alpha.8(@noble/hashes@2.0.1)(@types/node@25.1.0)(@types/react@19.2.10)(jiti@2.6.1)(yaml@2.8.2))(@sanity/client@7.14.1(debug@4.4.3))(vitest@3.2.4(@types/node@25.1.0)(jiti@2.6.1)(jsdom@26.1.0)(tsx@4.21.0)(yaml@2.8.2))
       '@sanity/client': 7.14.1(debug@4.4.3)
       '@sanity/mutate': 0.16.1(debug@4.4.3)(xstate@5.26.0)
       '@sanity/types': 5.7.0(@types/react@19.2.10)(debug@4.4.3)
@@ -8234,7 +8231,7 @@ snapshots:
       '@oclif/core': 4.8.0
       '@oclif/plugin-help': 6.2.37
       '@sanity/cli-core': 0.1.0-alpha.8(@noble/hashes@2.0.1)(@types/node@25.1.0)(@types/react@19.2.10)(jiti@2.6.1)(yaml@2.8.2)
-      '@sanity/cli-test': 0.0.2-alpha.7(@oclif/core@4.8.0)(@sanity/cli-core@0.1.0-alpha.8(@noble/hashes@2.0.1)(@types/node@25.1.0)(@types/react@19.2.10)(jiti@2.6.1)(yaml@2.8.2))(@sanity/client@7.14.1(debug@4.4.3))(vitest@3.2.4(@types/node@25.1.0)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@2.0.1))(tsx@4.21.0)(yaml@2.8.2))
+      '@sanity/cli-test': 0.0.2-alpha.7(@oclif/core@4.8.0)(@sanity/cli-core@0.1.0-alpha.8(@noble/hashes@2.0.1)(@types/node@25.1.0)(@types/react@19.2.10)(jiti@2.6.1)(yaml@2.8.2))(@sanity/client@7.14.1)(vitest@3.2.4(@types/node@25.1.0)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@2.0.1))(tsx@4.21.0)(yaml@2.8.2))
       '@sanity/client': 7.14.1(debug@4.4.3)
       '@sanity/mutate': 0.16.1(debug@4.4.3)(xstate@5.26.0)
       '@sanity/types': 5.7.0(@types/react@19.2.10)(debug@4.4.3)
@@ -8308,10 +8305,10 @@ snapshots:
       - '@types/react'
       - supports-color
 
-  '@sanity/presentation-comlink@2.0.1(@sanity/client@7.14.1(debug@4.4.3))(@sanity/types@5.7.0(@types/react@19.2.10))':
+  '@sanity/presentation-comlink@2.0.1(@sanity/client@7.14.1(debug@4.4.3))(@sanity/types@5.7.0(@types/react@19.2.10)(debug@4.4.3))':
     dependencies:
       '@sanity/comlink': 4.0.1
-      '@sanity/visual-editing-types': 1.1.8(@sanity/client@7.14.1(debug@4.4.3))(@sanity/types@5.7.0(@types/react@19.2.10))
+      '@sanity/visual-editing-types': 1.1.8(@sanity/client@7.14.1(debug@4.4.3))(@sanity/types@5.7.0(@types/react@19.2.10)(debug@4.4.3))
     transitivePeerDependencies:
       - '@sanity/client'
       - '@sanity/types'
@@ -8482,7 +8479,7 @@ snapshots:
       '@types/uuid': 8.3.4
       uuid: 8.3.2
 
-  '@sanity/vision@5.7.0(@babel/runtime@7.28.6)(@codemirror/lint@6.9.3)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.4.0)(codemirror@6.0.2)(react-dom@19.2.4(react@19.2.4))(react-is@19.2.4)(react@19.2.4)(sanity@5.7.0(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.0.1)(@types/node@25.1.0)(@types/react@19.2.10)(babel-plugin-react-compiler@1.0.0)(jiti@2.6.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-components@6.3.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(tsx@4.21.0)(typescript@5.9.3)(vitest@3.2.4(@types/node@25.1.0)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@2.0.1))(tsx@4.21.0)(yaml@2.8.2))(yaml@2.8.2))(styled-components@6.3.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
+  '@sanity/vision@5.7.0(@babel/runtime@7.28.6)(@codemirror/lint@6.9.3)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.4.0)(codemirror@6.0.2)(react-dom@19.2.4(react@19.2.4))(react-is@19.2.4)(react@19.2.4)(sanity@5.7.0(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.0.1)(@types/node@25.1.0)(@types/react@19.2.10)(babel-plugin-react-compiler@1.0.0)(jiti@2.6.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-components@6.3.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(tsx@4.21.0)(typescript@5.9.3)(vitest@3.2.4(@types/node@25.1.0)(jiti@2.6.1)(jsdom@26.1.0)(tsx@4.21.0)(yaml@2.8.2))(yaml@2.8.2))(styled-components@6.3.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
     dependencies:
       '@codemirror/autocomplete': 6.20.0
       '@codemirror/commands': 6.10.1
@@ -8509,7 +8506,7 @@ snapshots:
       react-fast-compare: 3.2.2
       react-rx: 4.2.2(react@19.2.4)(rxjs@7.8.2)
       rxjs: 7.8.2
-      sanity: 5.7.0(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.0.1)(@types/node@25.1.0)(@types/react@19.2.10)(babel-plugin-react-compiler@1.0.0)(jiti@2.6.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-components@6.3.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(tsx@4.21.0)(typescript@5.9.3)(vitest@3.2.4(@types/node@25.1.0)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@2.0.1))(tsx@4.21.0)(yaml@2.8.2))(yaml@2.8.2)
+      sanity: 5.7.0(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.0.1)(@types/node@25.1.0)(@types/react@19.2.10)(babel-plugin-react-compiler@1.0.0)(jiti@2.6.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-components@6.3.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(tsx@4.21.0)(typescript@5.9.3)(vitest@3.2.4(@types/node@25.1.0)(jiti@2.6.1)(jsdom@26.1.0)(tsx@4.21.0)(yaml@2.8.2))(yaml@2.8.2)
       styled-components: 6.3.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
     transitivePeerDependencies:
       - '@babel/runtime'
@@ -8529,7 +8526,7 @@ snapshots:
       - '@sanity/types'
       - typescript
 
-  '@sanity/visual-editing-types@1.1.8(@sanity/client@7.14.1(debug@4.4.3))(@sanity/types@5.7.0(@types/react@19.2.10))':
+  '@sanity/visual-editing-types@1.1.8(@sanity/client@7.14.1(debug@4.4.3))(@sanity/types@5.7.0(@types/react@19.2.10)(debug@4.4.3))':
     dependencies:
       '@sanity/client': 7.14.1(debug@4.4.3)
     optionalDependencies:
@@ -8545,9 +8542,9 @@ snapshots:
     dependencies:
       '@sanity/comlink': 4.0.1
       '@sanity/icons': 3.7.4(react@19.2.4)
-      '@sanity/insert-menu': 3.0.3(@emotion/is-prop-valid@1.4.0)(@sanity/types@5.7.0(@types/react@19.2.10))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-components@6.3.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+      '@sanity/insert-menu': 3.0.3(@emotion/is-prop-valid@1.4.0)(@sanity/types@5.7.0(@types/react@19.2.10)(debug@4.4.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-components@6.3.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       '@sanity/mutate': 0.16.1(debug@4.4.3)(xstate@5.26.0)
-      '@sanity/presentation-comlink': 2.0.1(@sanity/client@7.14.1(debug@4.4.3))(@sanity/types@5.7.0(@types/react@19.2.10))
+      '@sanity/presentation-comlink': 2.0.1(@sanity/client@7.14.1(debug@4.4.3))(@sanity/types@5.7.0(@types/react@19.2.10)(debug@4.4.3))
       '@sanity/preview-url-secret': 4.0.2(@sanity/client@7.14.1(debug@4.4.3))
       '@sanity/ui': 3.1.11(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.4(react@19.2.4))(react-is@19.2.4)(react@19.2.4)(styled-components@6.3.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       '@sanity/visual-editing-csm': 3.0.4(@sanity/client@7.14.1)(@sanity/types@5.7.0(@types/react@19.2.10))(typescript@5.9.3)
@@ -11073,12 +11070,12 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  next-sanity@12.0.15(@emotion/is-prop-valid@1.4.0)(@sanity/client@7.14.1)(@sanity/types@5.7.0(@types/react@19.2.10))(next@16.1.6(@babel/core@7.28.6)(@playwright/test@1.58.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-is@19.2.4)(react@19.2.4)(sanity@5.7.0(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.0.1)(@types/node@25.1.0)(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(babel-plugin-react-compiler@1.0.0)(jiti@2.6.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-components@6.3.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(tsx@4.21.0)(typescript@5.9.3)(vitest@3.2.4(@types/node@25.1.0)(jiti@2.6.1)(jsdom@26.1.0)(tsx@4.21.0)(yaml@2.8.2))(yaml@2.8.2))(styled-components@6.3.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3):
+  next-sanity@12.0.15(@emotion/is-prop-valid@1.4.0)(@sanity/client@7.14.1)(@sanity/types@5.7.0(@types/react@19.2.10))(next@16.1.6(@babel/core@7.28.6)(@playwright/test@1.58.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-is@19.2.4)(react@19.2.4)(sanity@5.7.0(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.0.1)(@types/node@25.1.0)(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(babel-plugin-react-compiler@1.0.0)(jiti@2.6.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-components@6.3.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(tsx@4.21.0)(typescript@5.9.3)(vitest@3.2.4(@types/node@25.1.0)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@2.0.1))(tsx@4.21.0)(yaml@2.8.2))(yaml@2.8.2))(styled-components@6.3.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3):
     dependencies:
       '@portabletext/react': 6.0.2(react@19.2.4)
       '@sanity/client': 7.14.1(debug@4.4.3)
       '@sanity/comlink': 4.0.1
-      '@sanity/presentation-comlink': 2.0.1(@sanity/client@7.14.1(debug@4.4.3))(@sanity/types@5.7.0(@types/react@19.2.10))
+      '@sanity/presentation-comlink': 2.0.1(@sanity/client@7.14.1(debug@4.4.3))(@sanity/types@5.7.0(@types/react@19.2.10)(debug@4.4.3))
       '@sanity/preview-url-secret': 4.0.2(@sanity/client@7.14.1(debug@4.4.3))
       '@sanity/visual-editing': 5.1.1(@emotion/is-prop-valid@1.4.0)(@sanity/client@7.14.1)(@sanity/types@5.7.0(@types/react@19.2.10))(next@16.1.6(@babel/core@7.28.6)(@playwright/test@1.58.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-is@19.2.4)(react@19.2.4)(styled-components@6.3.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)
       '@sanity/webhook': 4.0.4
@@ -11088,7 +11085,7 @@ snapshots:
       next: 16.1.6(@babel/core@7.28.6)(@playwright/test@1.58.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      sanity: 5.7.0(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.0.1)(@types/node@25.1.0)(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(babel-plugin-react-compiler@1.0.0)(jiti@2.6.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-components@6.3.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(tsx@4.21.0)(typescript@5.9.3)(vitest@3.2.4(@types/node@25.1.0)(jiti@2.6.1)(jsdom@26.1.0)(tsx@4.21.0)(yaml@2.8.2))(yaml@2.8.2)
+      sanity: 5.7.0(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.0.1)(@types/node@25.1.0)(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(babel-plugin-react-compiler@1.0.0)(jiti@2.6.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-components@6.3.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(tsx@4.21.0)(typescript@5.9.3)(vitest@3.2.4(@types/node@25.1.0)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@2.0.1))(tsx@4.21.0)(yaml@2.8.2))(yaml@2.8.2)
       server-only: 0.0.1
       styled-components: 6.3.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
     transitivePeerDependencies:
@@ -11778,7 +11775,7 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sanity@5.7.0(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.0.1)(@types/node@25.1.0)(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(babel-plugin-react-compiler@1.0.0)(jiti@2.6.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-components@6.3.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(tsx@4.21.0)(typescript@5.9.3)(vitest@3.2.4(@types/node@25.1.0)(jiti@2.6.1)(jsdom@26.1.0)(tsx@4.21.0)(yaml@2.8.2))(yaml@2.8.2):
+  sanity@5.7.0(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.0.1)(@types/node@25.1.0)(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(babel-plugin-react-compiler@1.0.0)(jiti@2.6.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-components@6.3.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(tsx@4.21.0)(typescript@5.9.3)(vitest@3.2.4(@types/node@25.1.0)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@2.0.1))(tsx@4.21.0)(yaml@2.8.2))(yaml@2.8.2):
     dependencies:
       '@algorithm.ts/lcs': 4.0.5
       '@date-fns/tz': 1.4.1
@@ -11815,13 +11812,13 @@ snapshots:
       '@sanity/id-utils': 1.0.0
       '@sanity/image-url': 2.0.3
       '@sanity/import': 4.1.0(@types/node@25.1.0)(@types/react@19.2.10)(jiti@2.6.1)(yaml@2.8.2)
-      '@sanity/insert-menu': 3.0.3(@emotion/is-prop-valid@1.4.0)(@sanity/types@5.7.0(@types/react@19.2.10))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-components@6.3.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+      '@sanity/insert-menu': 3.0.3(@emotion/is-prop-valid@1.4.0)(@sanity/types@5.7.0(@types/react@19.2.10)(debug@4.4.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-components@6.3.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       '@sanity/logos': 2.2.2(react@19.2.4)
       '@sanity/media-library-types': 1.2.0
       '@sanity/message-protocol': 0.19.0
-      '@sanity/migrate': 5.2.3(@noble/hashes@2.0.1)(@types/node@25.1.0)(@types/react@19.2.10)(jiti@2.6.1)(vitest@3.2.4(@types/node@25.1.0)(jiti@2.6.1)(jsdom@26.1.0)(tsx@4.21.0)(yaml@2.8.2))(xstate@5.26.0)(yaml@2.8.2)
+      '@sanity/migrate': 5.2.3(@noble/hashes@2.0.1)(@types/node@25.1.0)(@types/react@19.2.10)(jiti@2.6.1)(vitest@3.2.4(@types/node@25.1.0)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@2.0.1))(tsx@4.21.0)(yaml@2.8.2))(xstate@5.26.0)(yaml@2.8.2)
       '@sanity/mutator': 5.7.0(@types/react@19.2.10)
-      '@sanity/presentation-comlink': 2.0.1(@sanity/client@7.14.1(debug@4.4.3))(@sanity/types@5.7.0(@types/react@19.2.10))
+      '@sanity/presentation-comlink': 2.0.1(@sanity/client@7.14.1(debug@4.4.3))(@sanity/types@5.7.0(@types/react@19.2.10)(debug@4.4.3))
       '@sanity/preview-url-secret': 4.0.2(@sanity/client@7.14.1(debug@4.4.3))
       '@sanity/schema': 5.7.0(@types/react@19.2.10)(debug@4.4.3)
       '@sanity/sdk': 2.1.2(@types/react@19.2.10)(debug@4.4.3)(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))
@@ -11958,7 +11955,7 @@ snapshots:
       - vitest
       - yaml
 
-  sanity@5.7.0(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.0.1)(@types/node@25.1.0)(@types/react@19.2.10)(babel-plugin-react-compiler@1.0.0)(jiti@2.6.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-components@6.3.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(tsx@4.21.0)(typescript@5.9.3)(vitest@3.2.4(@types/node@25.1.0)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@2.0.1))(tsx@4.21.0)(yaml@2.8.2))(yaml@2.8.2):
+  sanity@5.7.0(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.0.1)(@types/node@25.1.0)(@types/react@19.2.10)(babel-plugin-react-compiler@1.0.0)(jiti@2.6.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-components@6.3.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(tsx@4.21.0)(typescript@5.9.3)(vitest@3.2.4(@types/node@25.1.0)(jiti@2.6.1)(jsdom@26.1.0)(tsx@4.21.0)(yaml@2.8.2))(yaml@2.8.2):
     dependencies:
       '@algorithm.ts/lcs': 4.0.5
       '@date-fns/tz': 1.4.1
@@ -11995,13 +11992,13 @@ snapshots:
       '@sanity/id-utils': 1.0.0
       '@sanity/image-url': 2.0.3
       '@sanity/import': 4.1.0(@types/node@25.1.0)(@types/react@19.2.10)(jiti@2.6.1)(yaml@2.8.2)
-      '@sanity/insert-menu': 3.0.3(@emotion/is-prop-valid@1.4.0)(@sanity/types@5.7.0(@types/react@19.2.10))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-components@6.3.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+      '@sanity/insert-menu': 3.0.3(@emotion/is-prop-valid@1.4.0)(@sanity/types@5.7.0(@types/react@19.2.10)(debug@4.4.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-components@6.3.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       '@sanity/logos': 2.2.2(react@19.2.4)
       '@sanity/media-library-types': 1.2.0
       '@sanity/message-protocol': 0.19.0
-      '@sanity/migrate': 5.2.3(@noble/hashes@2.0.1)(@types/node@25.1.0)(@types/react@19.2.10)(jiti@2.6.1)(vitest@3.2.4(@types/node@25.1.0)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@2.0.1))(tsx@4.21.0)(yaml@2.8.2))(xstate@5.26.0)(yaml@2.8.2)
+      '@sanity/migrate': 5.2.3(@noble/hashes@2.0.1)(@types/node@25.1.0)(@types/react@19.2.10)(jiti@2.6.1)(vitest@3.2.4(@types/node@25.1.0)(jiti@2.6.1)(jsdom@26.1.0)(tsx@4.21.0)(yaml@2.8.2))(xstate@5.26.0)(yaml@2.8.2)
       '@sanity/mutator': 5.7.0(@types/react@19.2.10)
-      '@sanity/presentation-comlink': 2.0.1(@sanity/client@7.14.1(debug@4.4.3))(@sanity/types@5.7.0(@types/react@19.2.10))
+      '@sanity/presentation-comlink': 2.0.1(@sanity/client@7.14.1(debug@4.4.3))(@sanity/types@5.7.0(@types/react@19.2.10)(debug@4.4.3))
       '@sanity/preview-url-secret': 4.0.2(@sanity/client@7.14.1(debug@4.4.3))
       '@sanity/schema': 5.7.0(@types/react@19.2.10)(debug@4.4.3)
       '@sanity/sdk': 2.1.2(@types/react@19.2.10)(debug@4.4.3)(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))


### PR DESCRIPTION
## Summary

- **CLS**: Use `aspect-ratio` CSS property instead of fixed heights for image containers, preventing layout shifts when images load
- **LCP**: Add `priority` prop to first property card on listing page for faster largest contentful paint
- **INP**: Extract reduced motion detection to shared `useReducedMotion` hook using `useSyncExternalStore` for better performance and SSR support

## Changes

| File | Change | Metric |
|------|--------|--------|
| `ImageCarousel.css` | Replace breakpoint heights with `aspect-ratio: 12/5` | CLS |
| `PropertyCard.tsx` | Add `aspectRatio: "400/220"` to image wrapper, add `priority` prop | CLS, LCP |
| `PropertiesGrid.tsx` | Pass `priority={true}` to first card | LCP |
| `TextImageSection.css` | Use `aspect-ratio: 1/1` for circular images | CLS |
| `useReducedMotion.ts` | New shared hook using `useSyncExternalStore` | INP |
| `ImageCarousel.tsx` | Use shared `useReducedMotion` hook | INP |

## Test plan

- [x] Build passes
- [x] 19/19 e2e tests pass (home, propiedades, navigation)
- [ ] Manual visual check on home, /propiedades, and property detail pages
- [ ] Verify no layout shifts when images load

🤖 Generated with [Claude Code](https://claude.com/claude-code)