### PR TITLE
feat: add Vercel Analytics and Google Analytics

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,6 +115,7 @@ Each app has its own `.env.local` file with different prefixes (Next.js uses `NE
 | `NEXT_PUBLIC_SANITY_DATASET`     | Sanity dataset name               |
 | `NEXT_PUBLIC_WEB3FORMS_KEY`      | Web3Forms API key for contact form|
 | `NEXT_PUBLIC_SITE_URL`           | Production site URL (for sitemap.xml and robots.txt) |
+| `NEXT_PUBLIC_GA_MEASUREMENT_ID`  | Google Analytics 4 measurement ID (optional, e.g. `G-XXXXXXXXXX`) |
 | `SANITY_REVALIDATE_SECRET`       | HMAC secret for Sanity webhook (server-only, no `NEXT_PUBLIC_` prefix) |
 
 ### Studio (`apps/studio/.env.local`)

--- a/README.md
+++ b/README.md
@@ -130,6 +130,48 @@ curl -s http://localhost:3000/api/revalidate \
 
 A successful response looks like: `{"revalidated":true,"tag":"property"}`
 
+## Analytics
+
+The site supports two analytics providers, both optional and independent of each other.
+
+### Vercel Analytics
+
+Tracks page views and real Core Web Vitals from actual users. No cookies, privacy-friendly, ~1KB script.
+
+**Setup:**
+
+1. Go to your [Vercel project dashboard](https://vercel.com/dashboard)
+2. Click the **Analytics** tab
+3. Click **Enable**
+
+That's it — the `<Analytics />` component is already in the code. It only sends data in production Vercel deployments.
+
+**Free tier:** 2,500 events/month.
+
+### Google Analytics (GA4)
+
+Provides detailed visitor insights, traffic sources, user flows, and property page engagement.
+
+**Setup:**
+
+1. Go to [analytics.google.com](https://analytics.google.com)
+2. Click **Start measuring** → create an Account (e.g., "DZTS Inmobiliaria")
+3. Create a **Property** (e.g., "DZTS Website")
+4. Choose **Web** as the platform and enter your site URL
+5. Copy your **Measurement ID** (looks like `G-XXXXXXXXXX`)
+6. Add it to your environment:
+
+```bash
+# apps/frontend/.env.local
+NEXT_PUBLIC_GA_MEASUREMENT_ID=G-XXXXXXXXXX
+```
+
+For Vercel deployments, add the same variable in **Vercel project settings → Environment Variables**.
+
+Google Analytics is conditionally loaded — if the env var is not set, no GA script is included.
+
+**Free tier:** Unlimited for most sites.
+
 ## E2E Tests
 
 The frontend includes Playwright end-to-end smoke tests in `apps/frontend/e2e/`. Tests assert page structure and navigation rather than CMS content, making them resilient to Sanity content changes.

--- a/apps/frontend/.env.example
+++ b/apps/frontend/.env.example
@@ -10,3 +10,6 @@ SANITY_REVALIDATE_SECRET=
 
 # Site URL (used for sitemap.xml and robots.txt)
 NEXT_PUBLIC_SITE_URL=https://yourdomain.com
+
+# Google Analytics (optional, get from https://analytics.google.com)
+NEXT_PUBLIC_GA_MEASUREMENT_ID=

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -12,11 +12,13 @@
     "test:e2e:headed": "playwright test --headed"
   },
   "dependencies": {
+    "@next/third-parties": "^16.1.6",
     "@popperjs/core": "^2.11.8",
     "@portabletext/react": "^6.0.2",
     "@portabletext/types": "^2.0.15",
     "@sanity/client": "^7.14.1",
     "@sanity/image-url": "^2.0.3",
+    "@vercel/analytics": "^1.6.1",
     "bootstrap": "^5.3.8",
     "bootstrap-icons": "^1.13.1",
     "next": "^16.1.6",
@@ -28,6 +30,7 @@
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.3",
     "@next/eslint-plugin-next": "^16.1.6",
+    "@playwright/test": "^1.52.0",
     "@types/node": "^25.1.0",
     "@types/react": "^19.2.10",
     "@types/react-dom": "^19.2.3",
@@ -37,7 +40,6 @@
     "eslint": "^9.39.2",
     "eslint-config-next": "^16.1.6",
     "eslint-plugin-react": "^7.37.5",
-    "@playwright/test": "^1.52.0",
     "typescript": "^5.9.3"
   }
 }

--- a/apps/frontend/src/app/layout.tsx
+++ b/apps/frontend/src/app/layout.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from "next";
 import { Suspense } from "react";
 import { cacheLife, cacheTag } from "next/cache";
 import { Inter } from "next/font/google";
+import { Analytics } from "@vercel/analytics/next";
+import { GoogleAnalytics } from "@next/third-parties/google";
 import BootstrapClient from "@/components/BootstrapClient";
 import Header from "@/components/Header";
 import Footer from "@/components/Footer";
@@ -18,6 +20,7 @@ const inter = Inter({
 });
 
 const siteUrl = process.env.NEXT_PUBLIC_SITE_URL;
+const gaId = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID;
 
 export const metadata: Metadata = {
   ...(siteUrl ? { metadataBase: new URL(siteUrl) } : {}),
@@ -86,6 +89,8 @@ export default function RootLayout({
           <SiteShell>{children}</SiteShell>
         </Suspense>
         <BootstrapClient />
+        <Analytics />
+        {gaId && <GoogleAnalytics gaId={gaId} />}
       </body>
     </html>
   );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,9 @@ importers:
 
   apps/frontend:
     dependencies:
+      '@next/third-parties':
+        specifier: ^16.1.6
+        version: 16.1.6(next@16.1.6(@babel/core@7.28.6)(@playwright/test@1.58.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
       '@popperjs/core':
         specifier: ^2.11.8
         version: 2.11.8
@@ -25,6 +28,9 @@ importers:
       '@sanity/image-url':
         specifier: ^2.0.3
         version: 2.0.3
+      '@vercel/analytics':
+        specifier: ^1.6.1
+        version: 1.6.1(next@16.1.6(@babel/core@7.28.6)(@playwright/test@1.58.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
       bootstrap:
         specifier: ^5.3.8
         version: 5.3.8(@popperjs/core@2.11.8)
@@ -1510,6 +1516,12 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@next/third-parties@16.1.6':
+    resolution: {integrity: sha512-/cLY1egaH529ylSMSK+C8dA3nWDLL4hOFR4fca9OLWWxjcNwzsbuq2pPb/tmdWL9Zj3K1nTjd1pWQoSlaDQ0VA==}
+    peerDependencies:
+      next: ^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0-beta.0
+      react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+
   '@noble/ed25519@3.0.0':
     resolution: {integrity: sha512-QyteqMNm0GLqfa5SoYbSC3+Pvykwpn95Zgth4MFVSMKBB75ELl9tX1LAVsN4c3HXOrakHsF2gL4zWDAYCcsnzg==}
 
@@ -2551,6 +2563,32 @@ packages:
     resolution: {integrity: sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==}
     cpu: [x64]
     os: [win32]
+
+  '@vercel/analytics@1.6.1':
+    resolution: {integrity: sha512-oH9He/bEM+6oKlv3chWuOOcp8Y6fo6/PSro8hEkgCW3pu9/OiCXiUpRUogDh3Fs3LH2sosDrx8CxeOLBEE+afg==}
+    peerDependencies:
+      '@remix-run/react': ^2
+      '@sveltejs/kit': ^1 || ^2
+      next: '>= 13'
+      react: ^18 || ^19 || ^19.0.0-rc
+      svelte: '>= 4'
+      vue: ^3
+      vue-router: ^4
+    peerDependenciesMeta:
+      '@remix-run/react':
+        optional: true
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+      vue-router:
+        optional: true
 
   '@vercel/edge@1.2.2':
     resolution: {integrity: sha512-1+y+f6rk0Yc9ss9bRDgz/gdpLimwoRteKHhrcgHvEpjbP1nyT3ByqEMWm2BTcpIO5UtDmIFXc8zdq4LR190PDA==}
@@ -5426,6 +5464,9 @@ packages:
   text-decoder@1.2.3:
     resolution: {integrity: sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==}
 
+  third-party-capital@1.0.20:
+    resolution: {integrity: sha512-oB7yIimd8SuGptespDAZnNkzIz+NWaJCu2RMsbs4Wmp9zSDUM8Nhi3s2OOcqYuv3mN4hitXc8DVx+LyUmbUDiA==}
+
   through2@2.0.5:
     resolution: {integrity: sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==}
 
@@ -7513,6 +7554,12 @@ snapshots:
   '@next/swc-win32-x64-msvc@16.1.6':
     optional: true
 
+  '@next/third-parties@16.1.6(next@16.1.6(@babel/core@7.28.6)(@playwright/test@1.58.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      next: 16.1.6(@babel/core@7.28.6)(@playwright/test@1.58.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      third-party-capital: 1.0.20
+
   '@noble/ed25519@3.0.0': {}
 
   '@noble/hashes@2.0.1': {}
@@ -8949,6 +8996,11 @@ snapshots:
 
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
+
+  '@vercel/analytics@1.6.1(next@16.1.6(@babel/core@7.28.6)(@playwright/test@1.58.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)':
+    optionalDependencies:
+      next: 16.1.6(@babel/core@7.28.6)(@playwright/test@1.58.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
 
   '@vercel/edge@1.2.2': {}
 
@@ -12527,6 +12579,8 @@ snapshots:
       b4a: 1.7.3
     transitivePeerDependencies:
       - react-native-b4a
+
+  third-party-capital@1.0.20: {}
 
   through2@2.0.5:
     dependencies:


### PR DESCRIPTION
## Summary

- Add **Vercel Analytics** for page views and real-user Core Web Vitals monitoring (~1KB, no cookies)
- Add **Google Analytics (GA4)** for visitor insights, traffic sources, and property page engagement
- Both providers are optional and independent — the site works fine without either

## How it works

- **Vercel Analytics**: Always included via `<Analytics />` component. Only sends data on production Vercel deployments. Enable in Vercel dashboard → Analytics tab.
- **Google Analytics**: Conditionally loaded only when `NEXT_PUBLIC_GA_MEASUREMENT_ID` env var is set. No GA script is included otherwise.

## Changes

| File | Change |
|------|--------|
| `layout.tsx` | Add `<Analytics />` and conditional `<GoogleAnalytics />` components |
| `package.json` | Add `@vercel/analytics` and `@next/third-parties` dependencies |
| `.env.example` | Add `NEXT_PUBLIC_GA_MEASUREMENT_ID` variable |
| `README.md` | Add Analytics section with setup instructions for both providers |
| `CLAUDE.md` | Add GA env var to environment variables table |

## Test plan

- [x] Build passes
- [x] Lint passes
- [x] GA script not included when env var is unset (current state)
- [ ] Verify Vercel Analytics appears in Vercel dashboard after deploy
- [ ] Verify GA4 tracking after setting measurement ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)