### PR TITLE
feat: add fullscreen image lightbox to property detail carousel

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -24,7 +24,8 @@
     "next": "^16.1.6",
     "next-sanity": "^12.0.15",
     "react": "^19.2.4",
-    "react-dom": "^19.2.4"
+    "react-dom": "^19.2.4",
+    "react-zoom-pan-pinch": "^3.7.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.3",

--- a/apps/frontend/src/components/Footer.tsx
+++ b/apps/frontend/src/components/Footer.tsx
@@ -80,6 +80,7 @@ export default function Footer({
                 alt={logoAlt}
                 width={150}
                 height={60}
+                style={{ width: "auto", height: "auto" }}
               />
             )}
           </div>

--- a/apps/frontend/src/components/ImageCarousel.css
+++ b/apps/frontend/src/components/ImageCarousel.css
@@ -1,4 +1,5 @@
 .carousel-image-container {
   aspect-ratio: 12/5;
   width: 100%;
+  cursor: pointer;
 }

--- a/apps/frontend/src/components/ImageCarousel.tsx
+++ b/apps/frontend/src/components/ImageCarousel.tsx
@@ -72,6 +72,7 @@ export default function ImageCarousel({ images, title }: ImageCarouselProps) {
                 className="carousel-image-container position-relative"
                 role="button"
                 tabIndex={0}
+                aria-label="Ver imagen en pantalla completa"
                 onClick={() => {
                   setLightboxIndex(index);
                   setLightboxOpen(true);

--- a/apps/frontend/src/components/ImageCarousel.tsx
+++ b/apps/frontend/src/components/ImageCarousel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useCallback } from "react";
 import dynamic from "next/dynamic";
 import { urlFor } from "@/sanity/lib/image";
 import type { SanityImageSource } from "@sanity/image-url";
@@ -24,6 +24,7 @@ export default function ImageCarousel({ images, title }: ImageCarouselProps) {
   const prefersReducedMotion = useReducedMotion();
   const [lightboxOpen, setLightboxOpen] = useState(false);
   const [lightboxIndex, setLightboxIndex] = useState(0);
+  const hideLightbox = useCallback(() => setLightboxOpen(false), []);
 
   if (images.length === 0) {
     return (
@@ -121,13 +122,15 @@ export default function ImageCarousel({ images, title }: ImageCarouselProps) {
           </button>
         </>
       )}
-      <ImageLightbox
-        show={lightboxOpen}
-        onHide={() => setLightboxOpen(false)}
-        images={images}
-        title={title}
-        initialIndex={lightboxIndex}
-      />
+      {lightboxOpen && (
+        <ImageLightbox
+          show={lightboxOpen}
+          onHide={hideLightbox}
+          images={images}
+          title={title}
+          initialIndex={lightboxIndex}
+        />
+      )}
     </div>
   );
 }

--- a/apps/frontend/src/components/ImageCarousel.tsx
+++ b/apps/frontend/src/components/ImageCarousel.tsx
@@ -1,10 +1,14 @@
 "use client";
 
+import { useState } from "react";
+import dynamic from "next/dynamic";
 import { urlFor } from "@/sanity/lib/image";
 import type { SanityImageSource } from "@sanity/image-url";
 import Image from "next/image";
 import { useReducedMotion } from "@/hooks/useReducedMotion";
 import "./ImageCarousel.css";
+
+const ImageLightbox = dynamic(() => import("./ImageLightbox"), { ssr: false });
 
 interface CarouselImage {
   asset?: SanityImageSource | null;
@@ -18,6 +22,8 @@ interface ImageCarouselProps {
 
 export default function ImageCarousel({ images, title }: ImageCarouselProps) {
   const prefersReducedMotion = useReducedMotion();
+  const [lightboxOpen, setLightboxOpen] = useState(false);
+  const [lightboxIndex, setLightboxIndex] = useState(0);
 
   if (images.length === 0) {
     return (
@@ -61,7 +67,22 @@ export default function ImageCarousel({ images, title }: ImageCarouselProps) {
 
           return (
             <div key={index} className={`carousel-item ${index === 0 ? 'active' : ''}`}>
-              <div className="carousel-image-container position-relative">
+              <div
+                className="carousel-image-container position-relative"
+                role="button"
+                tabIndex={0}
+                onClick={() => {
+                  setLightboxIndex(index);
+                  setLightboxOpen(true);
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    setLightboxIndex(index);
+                    setLightboxOpen(true);
+                  }
+                }}
+              >
                 <Image
                   src={url}
                   alt={`${title} - Imagen ${index + 1}`}
@@ -100,6 +121,13 @@ export default function ImageCarousel({ images, title }: ImageCarouselProps) {
           </button>
         </>
       )}
+      <ImageLightbox
+        show={lightboxOpen}
+        onHide={() => setLightboxOpen(false)}
+        images={images}
+        title={title}
+        initialIndex={lightboxIndex}
+      />
     </div>
   );
 }

--- a/apps/frontend/src/components/ImageLightbox.css
+++ b/apps/frontend/src/components/ImageLightbox.css
@@ -1,0 +1,37 @@
+.lightbox-image-container {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  touch-action: none;
+}
+
+.lightbox-counter {
+  position: absolute;
+  bottom: 1rem;
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(0, 0, 0, 0.6);
+  color: #fff;
+  padding: 0.25rem 0.75rem;
+  border-radius: 1rem;
+  font-size: 0.875rem;
+  z-index: 1;
+  pointer-events: none;
+}
+
+.lightbox-close {
+  top: max(0.75rem, env(safe-area-inset-top));
+  right: max(0.75rem, env(safe-area-inset-right));
+  z-index: 10;
+  padding: 1rem;
+}
+
+.lightbox-nav {
+  position: absolute;
+  top: 0;
+  height: 100%;
+  width: 10%;
+  border: none;
+  opacity: 0.8;
+  z-index: 1;
+}

--- a/apps/frontend/src/components/ImageLightbox.tsx
+++ b/apps/frontend/src/components/ImageLightbox.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useRef, useCallback } from "react";
+import { createPortal } from "react-dom";
 import { TransformWrapper, TransformComponent } from "react-zoom-pan-pinch";
 import type { ReactZoomPanPinchRef } from "react-zoom-pan-pinch";
 import { urlFor } from "@/sanity/lib/image";
@@ -157,7 +158,7 @@ export default function ImageLightbox({
     ? urlFor(currentImage.asset).width(1920).auto("format").quality(85).url()
     : null;
 
-  return (
+  return createPortal(
     <>
       <div
         className="modal-backdrop fade show"
@@ -282,6 +283,7 @@ export default function ImageLightbox({
           </div>
         </div>
       </div>
-    </>
+    </>,
+    document.body
   );
 }

--- a/apps/frontend/src/components/ImageLightbox.tsx
+++ b/apps/frontend/src/components/ImageLightbox.tsx
@@ -1,0 +1,287 @@
+"use client";
+
+import { useState, useEffect, useRef, useCallback } from "react";
+import { TransformWrapper, TransformComponent } from "react-zoom-pan-pinch";
+import type { ReactZoomPanPinchRef } from "react-zoom-pan-pinch";
+import { urlFor } from "@/sanity/lib/image";
+import type { SanityImageSource } from "@sanity/image-url";
+import { useReducedMotion } from "@/hooks/useReducedMotion";
+import "./ImageLightbox.css";
+
+interface LightboxImage {
+  asset?: SanityImageSource | null;
+  lqip?: string | null;
+}
+
+interface ImageLightboxProps {
+  show: boolean;
+  onHide: () => void;
+  images: LightboxImage[];
+  title: string;
+  initialIndex: number;
+}
+
+const FOCUSABLE_SELECTOR =
+  'button:not([disabled]), [href], [tabindex]:not([tabindex="-1"])';
+
+export default function ImageLightbox({
+  show,
+  onHide,
+  images,
+  title,
+  initialIndex,
+}: ImageLightboxProps) {
+  const [currentIndex, setCurrentIndex] = useState(initialIndex);
+  const [imageLoaded, setImageLoaded] = useState(false);
+  const prefersReducedMotion = useReducedMotion();
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+  const transformRef = useRef<ReactZoomPanPinchRef>(null);
+  const touchStartX = useRef(0);
+  const currentScale = useRef(1);
+
+  useEffect(() => {
+    setCurrentIndex(initialIndex);
+  }, [initialIndex]);
+
+  useEffect(() => {
+    setImageLoaded(false);
+  }, [currentIndex]);
+
+  const goTo = useCallback(
+    (index: number) => {
+      transformRef.current?.resetTransform(0);
+      currentScale.current = 1;
+      setCurrentIndex(index);
+    },
+    []
+  );
+
+  const goPrev = useCallback(() => {
+    if (images.length <= 1) return;
+    goTo(currentIndex === 0 ? images.length - 1 : currentIndex - 1);
+  }, [currentIndex, images.length, goTo]);
+
+  const goNext = useCallback(() => {
+    if (images.length <= 1) return;
+    goTo(currentIndex === images.length - 1 ? 0 : currentIndex + 1);
+  }, [currentIndex, images.length, goTo]);
+
+  // Scroll lock
+  useEffect(() => {
+    if (show) {
+      document.body.style.overflow = "hidden";
+    } else {
+      document.body.style.overflow = "";
+    }
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [show]);
+
+  // Focus management + keyboard + focus trap
+  useEffect(() => {
+    if (!show) return;
+
+    requestAnimationFrame(() => {
+      closeButtonRef.current?.focus();
+    });
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        onHide();
+        return;
+      }
+
+      if (e.key === "ArrowLeft") {
+        e.preventDefault();
+        goPrev();
+        return;
+      }
+
+      if (e.key === "ArrowRight") {
+        e.preventDefault();
+        goNext();
+        return;
+      }
+
+      if (e.key !== "Tab") return;
+
+      const dialog = dialogRef.current;
+      if (!dialog) return;
+
+      const focusable =
+        dialog.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR);
+      if (focusable.length === 0) return;
+
+      const firstEl = focusable[0];
+      const lastEl = focusable[focusable.length - 1];
+
+      if (e.shiftKey && document.activeElement === firstEl) {
+        e.preventDefault();
+        lastEl.focus();
+      } else if (!e.shiftKey && document.activeElement === lastEl) {
+        e.preventDefault();
+        firstEl.focus();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [show, onHide, goPrev, goNext]);
+
+  const handleTouchStart = useCallback((e: React.TouchEvent) => {
+    touchStartX.current = e.touches[0].clientX;
+  }, []);
+
+  const handleTouchEnd = useCallback(
+    (e: React.TouchEvent) => {
+      if (currentScale.current > 1) return;
+
+      const diff = touchStartX.current - e.changedTouches[0].clientX;
+      if (Math.abs(diff) > 50) {
+        if (diff > 0) {
+          goNext();
+        } else {
+          goPrev();
+        }
+      }
+    },
+    [goNext, goPrev]
+  );
+
+  if (!show) return null;
+
+  const currentImage = images[currentIndex];
+  const imageUrl = currentImage?.asset
+    ? urlFor(currentImage.asset).width(1920).auto("format").quality(85).url()
+    : null;
+
+  return (
+    <>
+      <div
+        className="modal-backdrop fade show"
+        style={{ zIndex: 1055 }}
+        aria-hidden="true"
+      />
+      <div
+        className="modal fade show"
+        style={{ display: "block", zIndex: 1056 }}
+        tabIndex={-1}
+        role="dialog"
+        aria-label={`Galería de imágenes: ${title}`}
+        aria-modal="true"
+        onClick={onHide}
+      >
+        <div
+          ref={dialogRef}
+          className="modal-dialog modal-fullscreen"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <div className="modal-content bg-black border-0">
+            <button
+              ref={closeButtonRef}
+              type="button"
+              className="btn-close btn-close-white position-absolute lightbox-close"
+              onClick={onHide}
+              aria-label="Cerrar galería"
+            />
+
+            <div
+              className="modal-body d-flex align-items-center justify-content-center p-0 position-relative"
+              onTouchStart={handleTouchStart}
+              onTouchEnd={handleTouchEnd}
+            >
+              {imageUrl && (
+                <div className="lightbox-image-container d-flex align-items-center justify-content-center">
+                  <TransformWrapper
+                    ref={transformRef}
+                    doubleClick={{ mode: "toggle" }}
+                    panning={{ velocityDisabled: true }}
+                    smooth={!prefersReducedMotion}
+                    onTransformed={(_ref, state) => {
+                      currentScale.current = state.scale;
+                    }}
+                  >
+                    <TransformComponent
+                      wrapperStyle={{ width: "100%", height: "100%" }}
+                      contentStyle={{
+                        width: "100%",
+                        height: "100%",
+                        display: "flex",
+                        alignItems: "center",
+                        justifyContent: "center",
+                      }}
+                    >
+                      {/* eslint-disable-next-line @next/next/no-img-element */}
+                      <img
+                        src={imageUrl}
+                        alt={`${title} - Imagen ${currentIndex + 1}`}
+                        style={{
+                          objectFit: "contain",
+                          maxWidth: "100%",
+                          maxHeight: "100vh",
+                          ...(currentImage.lqip && !imageLoaded
+                            ? {
+                                backgroundImage: `url(${currentImage.lqip})`,
+                                backgroundSize: "cover",
+                                backgroundPosition: "center",
+                              }
+                            : {}),
+                        }}
+                        onLoad={() => setImageLoaded(true)}
+                      />
+                    </TransformComponent>
+                  </TransformWrapper>
+                </div>
+              )}
+
+              {images.length > 1 && (
+                <>
+                  <button
+                    className="carousel-control-prev lightbox-nav"
+                    type="button"
+                    onClick={goPrev}
+                    style={{
+                      left: 0,
+                      background:
+                        "linear-gradient(to right, rgba(0,0,0,0.4), transparent)",
+                    }}
+                  >
+                    <span
+                      className="carousel-control-prev-icon"
+                      aria-hidden="true"
+                    />
+                    <span className="visually-hidden">Anterior</span>
+                  </button>
+                  <button
+                    className="carousel-control-next lightbox-nav"
+                    type="button"
+                    onClick={goNext}
+                    style={{
+                      right: 0,
+                      background:
+                        "linear-gradient(to left, rgba(0,0,0,0.4), transparent)",
+                    }}
+                  >
+                    <span
+                      className="carousel-control-next-icon"
+                      aria-hidden="true"
+                    />
+                    <span className="visually-hidden">Siguiente</span>
+                  </button>
+                </>
+              )}
+
+              {images.length > 1 && (
+                <div className="lightbox-counter" aria-live="polite">
+                  {currentIndex + 1} / {images.length}
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,6 +49,9 @@ importers:
       react-dom:
         specifier: ^19.2.4
         version: 19.2.4(react@19.2.4)
+      react-zoom-pan-pinch:
+        specifier: ^3.7.0
+        version: 3.7.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
     devDependencies:
       '@eslint/eslintrc':
         specifier: ^3.3.3
@@ -4972,6 +4975,13 @@ packages:
     peerDependencies:
       react: ^18.3 || >=19.0.0-0
       rxjs: ^7
+
+  react-zoom-pan-pinch@3.7.0:
+    resolution: {integrity: sha512-UmReVZ0TxlKzxSbYiAj+LeGRW8s8LraAFTXRAxzMYnNRgGPsxCudwZKVkjvGmjtx7SW/hZamt69NUmGf4xrkXA==}
+    engines: {node: '>=8', npm: '>=5'}
+    peerDependencies:
+      react: '*'
+      react-dom: '*'
 
   react@19.2.4:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
@@ -11608,6 +11618,11 @@ snapshots:
       react-compiler-runtime: 1.0.0(react@19.2.4)
       rxjs: 7.8.2
       use-effect-event: 2.0.3(react@19.2.4)
+
+  react-zoom-pan-pinch@3.7.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
 
   react@19.2.4: {}
 


### PR DESCRIPTION
## Summary

- Adds a fullscreen lightbox modal that opens when clicking any property carousel image, showing the image at full resolution (uncropped) with pinch-to-zoom, double-tap zoom, scroll-wheel zoom, and pan
- Navigation between images via prev/next buttons, arrow keys, and swipe gestures (when not zoomed)
- Full accessibility: focus trap, keyboard navigation (Escape/Arrows), `aria-modal`, `aria-live` counter, screen reader support
- Fixes Footer logo aspect ratio console warning by adding `style={{ width: "auto", height: "auto" }}`

## New dependency

- `react-zoom-pan-pinch` (~8KB gzipped) for zoom/pan gestures

## Test plan

- [ ] Click carousel image → lightbox opens fullscreen with black background
- [ ] Image displays at full aspect ratio (not cropped to 12:5)
- [ ] Pinch to zoom on mobile, scroll wheel on desktop, double-tap to toggle zoom
- [ ] Pan zoomed image with finger/mouse drag
- [ ] Prev/next buttons navigate between images, zoom resets on navigation
- [ ] Swipe left/right navigates when not zoomed in
- [ ] Counter shows correct "N / M"
- [ ] Escape key closes, arrow keys navigate
- [ ] Close button works on mobile (adequate tap target)
- [ ] Single-image properties show no navigation controls or counter
- [ ] Page carousel still works after closing lightbox
- [ ] Existing e2e tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)