### PR TITLE
feat: add configurable credit line to footer

### DIFF
--- a/apps/frontend/src/app/layout.tsx
+++ b/apps/frontend/src/app/layout.tsx
@@ -60,6 +60,7 @@ async function SiteShell({ children }: { children: React.ReactNode }) {
         phone={siteSettings?.phone}
         email={siteSettings?.email}
         address={siteSettings?.address}
+        creditLine={siteSettings?.creditLine}
       />
       {siteSettings?.whatsappNumber && (
         <WhatsAppButton

--- a/apps/frontend/src/components/Footer.css
+++ b/apps/frontend/src/components/Footer.css
@@ -117,3 +117,21 @@ a.footer-contact-item:hover {
     text-align: center;
   }
 }
+
+.footer-credit {
+  margin-top: 1rem;
+  padding-top: 0.75rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.15);
+  text-align: center;
+  font-size: 0.75rem;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.footer-credit a {
+  color: rgba(255, 255, 255, 0.5);
+  text-decoration: none;
+}
+
+.footer-credit a:hover {
+  color: rgba(255, 255, 255, 0.8);
+}

--- a/apps/frontend/src/components/Footer.css
+++ b/apps/frontend/src/components/Footer.css
@@ -122,7 +122,8 @@ a.footer-contact-item:hover {
   margin-top: 1rem;
   padding-top: 0.75rem;
   border-top: 1px solid rgba(255, 255, 255, 0.15);
-  text-align: center;
+  display: flex;
+  justify-content: center;
   font-size: 0.75rem;
   color: rgba(255, 255, 255, 0.5);
 }

--- a/apps/frontend/src/components/Footer.css
+++ b/apps/frontend/src/components/Footer.css
@@ -37,7 +37,12 @@ a.footer-contact-item:hover {
 .footer-content {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+}
+
+.footer-logo {
+  flex: 1;
+  display: flex;
+  justify-content: flex-start;
 }
 
 .footer-logo img {
@@ -47,6 +52,7 @@ a.footer-contact-item:hover {
 }
 
 .footer-center {
+  flex: 1;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -92,9 +98,11 @@ a.footer-contact-item:hover {
 
 
 .footer-certifications {
+  flex: 1;
   display: flex;
   gap: 1rem;
   align-items: center;
+  justify-content: flex-end;
 }
 
 .cert-placeholder {

--- a/apps/frontend/src/components/Footer.tsx
+++ b/apps/frontend/src/components/Footer.tsx
@@ -15,6 +15,7 @@ type FooterProps = {
   phone?: SiteSettings["phone"];
   email?: SiteSettings["email"];
   address?: SiteSettings["address"];
+  creditLine?: SiteSettings["creditLine"];
 };
 
 const platformIcons: Record<string, string> = {
@@ -33,6 +34,7 @@ export default function Footer({
   phone,
   email,
   address,
+  creditLine,
 }: FooterProps) {
   const logoUrl = logo?.asset ? urlFor(logo).width(300).url() : null;
   const logoAlt = logo?.alt || siteName || "";
@@ -144,6 +146,21 @@ export default function Footer({
             })}
           </div>
         </div>
+        {creditLine?.text && (
+          <div className="footer-credit">
+            {creditLine.url ? (
+              <a
+                href={creditLine.url}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {creditLine.text}
+              </a>
+            ) : (
+              <span>{creditLine.text}</span>
+            )}
+          </div>
+        )}
       </div>
     </footer>
   );

--- a/apps/frontend/src/sanity/queries/siteSettings.ts
+++ b/apps/frontend/src/sanity/queries/siteSettings.ts
@@ -101,6 +101,10 @@ export const SITE_SETTINGS_QUERY = defineQuery(/* groq */ `
       alt,
       title,
       url
+    },
+    creditLine {
+      text,
+      url
     }
   }
 `);

--- a/apps/frontend/src/sanity/types.ts
+++ b/apps/frontend/src/sanity/types.ts
@@ -751,6 +751,10 @@ export type SITE_SETTINGS_QUERY_RESULT = {
     title: string | null;
     url: string | null;
   }> | null;
+  creditLine: {
+    text: string | null;
+    url: string | null;
+  } | null;
 } | null;
 
 // Query TypeMap
@@ -773,6 +777,6 @@ declare module "@sanity/client" {
     '\n  *[_type == "homePage"][0].seo {\n  metaTitle,\n  metaDescription,\n  ogImage { asset->{ url } },\n  noIndex\n}\n': HOME_SEO_QUERY_RESULT;
     '\n  *[_type == "propiedadesPage"][0].seo {\n  metaTitle,\n  metaDescription,\n  ogImage { asset->{ url } },\n  noIndex\n}\n': PROPIEDADES_SEO_QUERY_RESULT;
     '\n  *[_type == "siteSettings"][0] {\n    siteName,\n    logo { asset->{ url } },\n    phone,\n    email,\n    address,\n    socialLinks[] { url }\n  }\n': ORGANIZATION_QUERY_RESULT;
-    '\n  *[_type == "siteSettings"][0] {\n    siteName,\n    logo {\n      asset->{\n        _id,\n        url,\n        metadata { lqip, dimensions }\n      },\n      alt\n    },\n    favicon {\n      asset->{\n        _id,\n        url\n      }\n    },\n    mainNavigation[] {\n      _key,\n      label,\n      linkType,\n      internalPath,\n      externalUrl,\n      actionId\n    },\n    phone,\n    email,\n    address,\n    whatsappNumber,\n    whatsappMessage,\n    socialLinks[] {\n      _key,\n      platform,\n      url\n    },\n    footerLinks[] {\n      _key,\n      label,\n      url\n    },\n    certificationLogos[] {\n      _key,\n      image {\n        asset->{\n          _id,\n          url,\n          metadata { lqip, dimensions }\n        }\n      },\n      alt,\n      title,\n      url\n    }\n  }\n': SITE_SETTINGS_QUERY_RESULT;
+    '\n  *[_type == "siteSettings"][0] {\n    siteName,\n    logo {\n      asset->{\n        _id,\n        url,\n        metadata { lqip, dimensions }\n      },\n      alt\n    },\n    favicon {\n      asset->{\n        _id,\n        url\n      }\n    },\n    mainNavigation[] {\n      _key,\n      label,\n      linkType,\n      internalPath,\n      externalUrl,\n      actionId\n    },\n    phone,\n    email,\n    address,\n    whatsappNumber,\n    whatsappMessage,\n    socialLinks[] {\n      _key,\n      platform,\n      url\n    },\n    footerLinks[] {\n      _key,\n      label,\n      url\n    },\n    certificationLogos[] {\n      _key,\n      image {\n        asset->{\n          _id,\n          url,\n          metadata { lqip, dimensions }\n        }\n      },\n      alt,\n      title,\n      url\n    },\n    creditLine {\n      text,\n      url\n    }\n  }\n': SITE_SETTINGS_QUERY_RESULT;
   }
 }

--- a/apps/frontend/src/sanity/types.ts
+++ b/apps/frontend/src/sanity/types.ts
@@ -204,6 +204,10 @@ export type SiteSettings = {
     _type: "certificationLogo";
     _key: string;
   }>;
+  creditLine?: {
+    text?: string;
+    url?: string;
+  };
   seo?: Seo;
 };
 
@@ -686,7 +690,7 @@ export type ORGANIZATION_QUERY_RESULT = {
 
 // Source: ../frontend/src/sanity/queries/siteSettings.ts
 // Variable: SITE_SETTINGS_QUERY
-// Query: *[_type == "siteSettings"][0] {    siteName,    logo {      asset->{        _id,        url,        metadata { lqip, dimensions }      },      alt    },    favicon {      asset->{        _id,        url      }    },    mainNavigation[] {      _key,      label,      linkType,      internalPath,      externalUrl,      actionId    },    phone,    email,    address,    whatsappNumber,    whatsappMessage,    socialLinks[] {      _key,      platform,      url    },    footerLinks[] {      _key,      label,      url    },    certificationLogos[] {      _key,      image {        asset->{          _id,          url,          metadata { lqip, dimensions }        }      },      alt,      title,      url    }  }
+// Query: *[_type == "siteSettings"][0] {    siteName,    logo {      asset->{        _id,        url,        metadata { lqip, dimensions }      },      alt    },    favicon {      asset->{        _id,        url      }    },    mainNavigation[] {      _key,      label,      linkType,      internalPath,      externalUrl,      actionId    },    phone,    email,    address,    whatsappNumber,    whatsappMessage,    socialLinks[] {      _key,      platform,      url    },    footerLinks[] {      _key,      label,      url    },    certificationLogos[] {      _key,      image {        asset->{          _id,          url,          metadata { lqip, dimensions }        }      },      alt,      title,      url    },    creditLine {      text,      url    }  }
 export type SITE_SETTINGS_QUERY_RESULT = {
   siteName: string | null;
   logo: {

--- a/apps/studio/schema.json
+++ b/apps/studio/schema.json
@@ -1301,6 +1301,29 @@
         },
         "optional": true
       },
+      "creditLine": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "object",
+          "attributes": {
+            "text": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "string"
+              },
+              "optional": true
+            },
+            "url": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "string"
+              },
+              "optional": true
+            }
+          }
+        },
+        "optional": true
+      },
       "seo": {
         "type": "objectAttribute",
         "value": {

--- a/apps/studio/schemaTypes/siteSettingsType.ts
+++ b/apps/studio/schemaTypes/siteSettingsType.ts
@@ -264,6 +264,26 @@ export const siteSettingsType = defineType({
     }),
 
     defineField({
+      name: "creditLine",
+      title: "Línea de crédito",
+      type: "object",
+      group: "footer",
+      description: "Texto de atribución al pie del footer (ej: desarrollado por...)",
+      fields: [
+        defineField({
+          name: "text",
+          title: "Texto",
+          type: "string",
+        }),
+        defineField({
+          name: "url",
+          title: "URL",
+          type: "url",
+        }),
+      ],
+    }),
+
+    defineField({
       name: "seo",
       title: "SEO",
       type: "seo",


### PR DESCRIPTION
Adds a configurable credit line to the footer, managed via Sanity Site Settings.

## Changes
- New `creditLine` field in the `siteSettings` Sanity schema
- Footer renders the credit line when set in the CMS
- Footer middle section centered using equal flex columns
- Generated TypeScript types updated

## Notes
These commits were originally in the fork's `dev` branch and are being contributed back to the upstream repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)